### PR TITLE
First approeach to get a marker of last seen in buffers.

### DIFF
--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -28,6 +28,9 @@
                 message.nick && message.nick.toLowerCase() === hover_nick.toLowerCase() ?
                     'kiwi-messagelist-message--hover' :
                     '',
+                buffer.last_read && message.time > buffer.last_read ?
+                    'kiwi-messagelist-message--unread' :
+                    '',
             ]"
         >
             <div

--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -83,6 +83,7 @@ const stateObj = {
     ui: {
         active_network: 0,
         active_buffer: '',
+        active_timeout: null,
     },
     networks: [
         /* {
@@ -388,6 +389,24 @@ const state = new Vue({
                 if (buffer && buffer.flags.unread) {
                     buffer.flags.unread = 0;
                 }
+
+                // Update the buffers last read time
+                if (this.ui.active_timeout) {
+                    clearTimeout(this.ui.active_timeout);
+                }
+                this.ui.active_timeout = setTimeout(
+                    this.updateBufferLastRead,
+                    10000,
+                    networkid,
+                    bufferName
+                );
+            }
+        },
+
+        updateBufferLastRead: function updateBufferLastRead(networkid, bufferName) {
+            let buffer = this.getBufferByName(networkid, bufferName);
+            if (buffer) {
+                buffer.last_read = Date.now();
             }
         },
 
@@ -508,6 +527,10 @@ const state = new Vue({
                 buffer.networkid === this.ui.active_network &&
                 buffer.name === this.ui.active_buffer
             );
+
+            if (isActiveBuffer) {
+                buffer.last_read = message.time;
+            }
 
             if (includeAsActivity && !isActiveBuffer) {
                 buffer.incrementFlag('unread');
@@ -720,6 +743,7 @@ function createEmptyBufferObject() {
         },
         settings: {
         },
+        last_read: Date.now(),
     };
 }
 
@@ -879,4 +903,3 @@ function initialiseBufferState(buffer) {
         messages: [],
     });
 }
-

--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -83,7 +83,6 @@ const stateObj = {
     ui: {
         active_network: 0,
         active_buffer: '',
-        active_timeout: null,
     },
     networks: [
         /* {
@@ -391,10 +390,10 @@ const state = new Vue({
                 }
 
                 // Update the buffers last read time
-                if (this.ui.active_timeout) {
-                    clearTimeout(this.ui.active_timeout);
+                if (buffer.active_timeout) {
+                    clearTimeout(buffer.active_timeout);
                 }
-                this.ui.active_timeout = setTimeout(
+                buffer.active_timeout = setTimeout(
                     this.updateBufferLastRead,
                     10000,
                     networkid,
@@ -407,6 +406,7 @@ const state = new Vue({
             let buffer = this.getBufferByName(networkid, bufferName);
             if (buffer) {
                 buffer.last_read = Date.now();
+                buffer.active_timeout = null;
             }
         },
 
@@ -744,6 +744,7 @@ function createEmptyBufferObject() {
         settings: {
         },
         last_read: Date.now(),
+        active_timeout: null,
     };
 }
 

--- a/static/themes/default/theme.css
+++ b/static/themes/default/theme.css
@@ -482,6 +482,16 @@ p {
     background: #e3f1d4;
     border-left-color: #80ab52;
 }
+.kiwi-messagelist-message:not(.kiwi-messagelist-message--unread) + .kiwi-messagelist-message.kiwi-messagelist-message--unread {
+    background: #eeeeff;
+    border-left-color: #000088;
+}
+.kiwi-messagelist-message:not(.kiwi-messagelist-message--unread) + .kiwi-messagelist-message.kiwi-messagelist-message--unread > .kiwi-messagelist-body::after {
+    content: "You were here";
+    font-style: italic;
+    margin-left: 15px;
+    color: #000088;
+}
 .kiwi-messagelist-message > div {
     padding: 2px 4px;
 }


### PR DESCRIPTION
* Added last_read timestamp on each buffer.
* This timestamp updates when a message is added to the buffer and it is active or after 10 seconds being active.
* This 10 seconds time is done by setTimeout and this is canceled if you leave that window. Not convinced this is the best way, but first approach.
* Updated template MessageList.vue to add the class kiwi-messagelist-message--unread when message is added to a buffer and this is not active.
* Added some CSS rules to the default theme to see it.