### PR TITLE
More contrast to .kiwi-messagelist-time

### DIFF
--- a/static/themes/default/theme.css
+++ b/static/themes/default/theme.css
@@ -314,7 +314,7 @@
 }
 
 .kiwi-messagelist-time {
-    color: #c1c1c1;
+    color: #818181;
 }
 
 


### PR DESCRIPTION
It was too light. See also: http://contrastrebellion.com/