### PR TITLE
State browser channel popup fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 dist/
 npm-debug.log
 test/unit/coverage
+src/res/locales/available.json

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ node_modules/
 dist/
 npm-debug.log
 test/unit/coverage
-src/res/locales/available.json

--- a/src/components/StateBrowser.vue
+++ b/src/components/StateBrowser.vue
@@ -106,9 +106,14 @@ export default {
                 this.popup_networkid = null;
                 this.popup_top = 0;
             } else {
+                let h = 0;
+                let sb = document.getElementsByClassName('kiwi-statebrowser')[0];
+                if (sb.style && sb.style.top) {
+                    h = parseInt(sb.style.top, 10);
+                }
                 this.popup_buffername = buffer.name;
                 this.popup_networkid = buffer.networkid;
-                this.popup_top = domY;
+                this.popup_top = domY - h;
             }
         },
         closeBuffer: function closeBuffer() {

--- a/src/components/StateBrowser.vue
+++ b/src/components/StateBrowser.vue
@@ -109,7 +109,7 @@ export default {
                 let stateBrowserTopPosition = this.$el.getBoundingClientRect();
                 this.popup_buffername = buffer.name;
                 this.popup_networkid = buffer.networkid;
-                this.popup_top = domY - stateBrowserTopPosition;
+                this.popup_top = domY - stateBrowserTopPosition.top;
             }
         },
         closeBuffer: function closeBuffer() {

--- a/src/components/StateBrowser.vue
+++ b/src/components/StateBrowser.vue
@@ -106,14 +106,10 @@ export default {
                 this.popup_networkid = null;
                 this.popup_top = 0;
             } else {
-                let h = 0;
-                let sb = document.getElementsByClassName('kiwi-statebrowser')[0];
-                if (sb.style && sb.style.top) {
-                    h = parseInt(sb.style.top, 10);
-                }
+                let stateBrowserTopPosition = this.$el.getBoundingClientRect();
                 this.popup_buffername = buffer.name;
                 this.popup_networkid = buffer.networkid;
-                this.popup_top = domY - h;
+                this.popup_top = domY - stateBrowserTopPosition;
             }
         },
         closeBuffer: function closeBuffer() {


### PR DESCRIPTION
When statebrowser sidebar is not on the top of browser's window, popups are not rendering in the correct position.

This fix tries to see if kiwi-statebrowser has some CSS top parameter and, when rendering kiwi-statebrowser-channel-popup, uses it to render popup in the correct position.