### PR TITLE
Ban type configuration

### DIFF
--- a/src/components/AppSettings.vue
+++ b/src/components/AppSettings.vue
@@ -48,6 +48,12 @@
                         <label><span>{{$t('settings_mute_sound')}}: </span> <input type="checkbox" v-model="settingBufferMuteSound" /></label>
                         <label><span>{{$t('settings_highlight')}}: </span> <input type="text" class="u-input" v-model="settingHighlights" /></label>
                     </div>
+
+                    <div class="kiwi-appsettings-section kiwi-appsettings-operator-tools">
+                        <h3>{{$t('operator_tools')}}</h3>
+                        <label><span>{{$t('settings_default_ban_type')}}: </span> <input type="text" class="u-input" v-model="settingDefaultBanType" /></label>
+                        <label><span>{{$t('settings_default_kick_reason')}}: </span> <input type="text" class="u-input" v-model="settingDefaultKickReason" /></label>
+                    </div>
                 </tabbed-tab>
 
                 <tabbed-tab :header="$t('settings_aliases')">
@@ -121,6 +127,8 @@ export default {
         settingBufferExtraFormatting: bindSetting('buffers.extra_formatting'),
         settingBufferTrafficAsActivity: bindSetting('buffers.traffic_as_activity'),
         settingBufferMuteSound: bindSetting('buffers.mute_sound'),
+        settingDefaultBanType: bindSetting('buffers.default_ban_type'),
+        settingDefaultKickReason: bindSetting('buffers.default_kick_reason'),
         settingMessageLayout: {
             get: function getSettingMessageLayout() {
                 return state.setting('messageLayout') === 'compact';

--- a/src/components/AppSettings.vue
+++ b/src/components/AppSettings.vue
@@ -51,7 +51,7 @@
 
                     <div class="kiwi-appsettings-section kiwi-appsettings-operator-tools">
                         <h3>{{$t('operator_tools')}}</h3>
-                        <label><span>{{$t('settings_default_ban_type')}}: </span> <input type="text" class="u-input" v-model="settingDefaultBanType" /></label>
+                        <label><span>{{$t('settings_default_ban_mask')}}: </span> <input type="text" class="u-input" v-model="settingDefaultBanMask" /></label>
                         <label><span>{{$t('settings_default_kick_reason')}}: </span> <input type="text" class="u-input" v-model="settingDefaultKickReason" /></label>
                     </div>
                 </tabbed-tab>
@@ -127,7 +127,7 @@ export default {
         settingBufferExtraFormatting: bindSetting('buffers.extra_formatting'),
         settingBufferTrafficAsActivity: bindSetting('buffers.traffic_as_activity'),
         settingBufferMuteSound: bindSetting('buffers.mute_sound'),
-        settingDefaultBanType: bindSetting('buffers.default_ban_type'),
+        settingDefaultBanMask: bindSetting('buffers.default_ban_mask'),
         settingDefaultKickReason: bindSetting('buffers.default_kick_reason'),
         settingMessageLayout: {
             get: function getSettingMessageLayout() {

--- a/src/components/MessageInfo.vue
+++ b/src/components/MessageInfo.vue
@@ -49,7 +49,7 @@ export default {
         },
         onKick: function onKick(promptedReason) {
             let network = this.buffer.getNetwork();
-            let defaultReason = state.setting('buffer.default_kick_reason');
+            let defaultReason = state.setting('buffers.default_kick_reason');
             let reason = promptedReason || defaultReason;
             network.ircClient.raw('KICK', this.buffer.name, this.message.nick, reason);
         },

--- a/src/components/MessageInfo.vue
+++ b/src/components/MessageInfo.vue
@@ -49,7 +49,7 @@ export default {
         },
         onKick: function onKick(promptedReason) {
             let network = this.buffer.getNetwork();
-            let defaultReason = 'Your behavior is not conducive to the desired environment.';
+            let defaultReason = state.setting('buffer.default_kick_reason');
             let reason = promptedReason || defaultReason;
             network.ircClient.raw('KICK', this.buffer.name, this.message.nick, reason);
         },

--- a/src/components/UserBox.vue
+++ b/src/components/UserBox.vue
@@ -183,15 +183,23 @@ export default {
             });
         },
         kickUser: function kickUser() {
-            let reason = 'Your behavior is not conducive to the desired environment.';
+            let reason = state.setting('buffers.default_kick_reason');
             this.network.ircClient.raw('KICK', this.buffer.name, this.user.nick, reason);
+        },
+        banMask: function banMask() {
+            let mask = state.setting('buffers.default_ban_type');
+            mask = mask.replace('%n', this.user.nick);
+            mask = mask.replace('%i', this.user.username);
+            mask = mask.replace('%h', this.user.host);
+
+            return mask;
         },
         banUser: function banUser() {
             if (!this.user.username || !this.user.host) {
                 return;
             }
 
-            let banMask = `*!${this.user.username}@${this.user.host}`;
+            let banMask = this.banMask();
             this.network.ircClient.raw('MODE', this.buffer.name, '+b', banMask);
         },
         kickbanUser: function kickbanuser() {
@@ -199,8 +207,8 @@ export default {
                 return;
             }
 
-            let banMask = `*!${this.user.username}@${this.user.host}`;
-            let reason = 'Your behavior is not conducive to the desired environment.';
+            let banMask = this.banMask();
+            let reason = state.setting('buffers.default_kick_reason');
             this.network.ircClient.raw('MODE', this.buffer.name, '+b', banMask);
             this.network.ircClient.raw('KICK', this.buffer.name, this.user.nick, reason);
         },

--- a/src/components/UserBox.vue
+++ b/src/components/UserBox.vue
@@ -186,8 +186,8 @@ export default {
             let reason = state.setting('buffers.default_kick_reason');
             this.network.ircClient.raw('KICK', this.buffer.name, this.user.nick, reason);
         },
-        banMask: function banMask() {
-            let mask = state.setting('buffers.default_ban_type');
+        createBanMask: function banMask() {
+            let mask = state.setting('buffers.default_ban_mask');
             mask = mask.replace('%n', this.user.nick);
             mask = mask.replace('%i', this.user.username);
             mask = mask.replace('%h', this.user.host);
@@ -199,7 +199,7 @@ export default {
                 return;
             }
 
-            let banMask = this.banMask();
+            let banMask = this.createBanMask();
             this.network.ircClient.raw('MODE', this.buffer.name, '+b', banMask);
         },
         kickbanUser: function kickbanuser() {
@@ -207,7 +207,7 @@ export default {
                 return;
             }
 
-            let banMask = this.banMask();
+            let banMask = this.createBanMask();
             let reason = state.setting('buffers.default_kick_reason');
             this.network.ircClient.raw('MODE', this.buffer.name, '+b', banMask);
             this.network.ircClient.raw('KICK', this.buffer.name, this.user.nick, reason);

--- a/src/libs/IrcClient.js
+++ b/src/libs/IrcClient.js
@@ -318,6 +318,10 @@ function clientMiddleware(state, networkid) {
 
             let messageBody = '';
 
+            if (event.message === event.nick) {
+                event.message = state.setting('buffers.default_kick_reason');
+            }
+
             if (event.kicked === client.user.nick) {
                 buffer.joined = false;
                 messageBody = TextFormatting.formatText('channel_selfkick', {

--- a/src/libs/IrcClient.js
+++ b/src/libs/IrcClient.js
@@ -318,10 +318,6 @@ function clientMiddleware(state, networkid) {
 
             let messageBody = '';
 
-            if (event.message === event.nick) {
-                event.message = state.setting('buffers.default_kick_reason');
-            }
-
             if (event.kicked === client.user.nick) {
                 buffer.joined = false;
                 messageBody = TextFormatting.formatText('channel_selfkick', {

--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -48,7 +48,7 @@ const stateObj = {
             show_emoticons: true,
             extra_formatting: true,
             mute_sound: false,
-            default_ban_type: '*!%i@%h',
+            default_ban_mask: '*!%i@%h',
             default_kick_reason: 'Your behavior is not conducive to the desired environment.',
         },
         // Startup screen default

--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -48,6 +48,8 @@ const stateObj = {
             show_emoticons: true,
             extra_formatting: true,
             mute_sound: false,
+            default_ban_type: '*!%i@%h',
+            default_kick_reason: 'Your behavior is not conducive to the desired environment.',
         },
         // Startup screen default
         startupOptions: {

--- a/src/res/locales/app.dev.po
+++ b/src/res/locales/app.dev.po
@@ -198,6 +198,18 @@ msgstr "Never"
 msgid "settings_notify_mute"
 msgstr "Mute sounds"
 
+#: operator_tools
+msgid "operator_tools"
+msgstr "Operator tools"
+
+#: settings_default_ban_mask
+msgid "settings_default_ban_mask"
+msgstr "Default ban mask"
+
+#: settings_default_kick_reason
+msgid "settings_default_kick_reason"
+msgstr "Default kick reason"
+
 
 
 #: ChannelBanlist $t('bans_')


### PR DESCRIPTION
There are two new configurations:
- **default_ban_mask**: this is the default ban mask when using /ban command, Ban or Kickban button (defaults to *!%i@%h). %n is replaced by nick, %i by username and %h by host.
- **default_kick_reason**: this is the default kick reason when using Kick or Kickban button.

Both can be configured in settings under new section "**Operator tools**".

Also, there are 3 new texts to translate.