### PR TITLE
Improving ControlInput user experience for mobiles.

### DIFF
--- a/src/components/ControlInput.vue
+++ b/src/components/ControlInput.vue
@@ -6,7 +6,7 @@
 
         <div class="kiwi-controlinput-inner">
             <div v-if="currentNick" class="kiwi-controlinput-user" @click="toggleSelfUser">
-                {{ currentNick }}
+                <span class="kiwi-controlinput-user-nick">{{ currentNick }}</span>
                 <i class="fa fa-caret-up" aria-hidden="true"></i>
             </div>
             <form @submit.prevent="submitForm" class="kiwi-controlinput-form">

--- a/static/themes/common/layout.css
+++ b/static/themes/common/layout.css
@@ -452,6 +452,11 @@ div {
     font-weight: bold;
     text-align: center;
 }
+@media screen and (max-width: 500px) {
+    .kiwi-controlinput-user-nick {
+        display: none;
+    }
+}
 .kiwi-controlinput-tools {
     margin-left: 10px;
 }


### PR DESCRIPTION
We wrap the nick in Control Input into a <span /> tag and then, for mobiles (less than 500px width), we hide it and we leave only the arrow to open or close the popup.