### PR TITLE
This tries to make compat to old Android browsers

### DIFF
--- a/src/libs/ThemeManager.js
+++ b/src/libs/ThemeManager.js
@@ -16,10 +16,7 @@ export default class ThemeManager {
 
         let styles = window.getComputedStyle(this.varsEl);
         let v = styles.getPropertyValue('--kiwi-' + varName);
-        if (v) {
-            return v.trim();
-        }
-        return '';
+        return (v || '').trim();
     }
 
     availableThemes() {

--- a/src/libs/ThemeManager.js
+++ b/src/libs/ThemeManager.js
@@ -15,7 +15,11 @@ export default class ThemeManager {
         }
 
         let styles = window.getComputedStyle(this.varsEl);
-        return styles.getPropertyValue('--kiwi-' + varName).trim();
+        let v = styles.getPropertyValue('--kiwi-' + varName);
+        if (v) {
+            return v.trim();
+        }
+        return '';
     }
 
     availableThemes() {


### PR DESCRIPTION
CSSStyleDeclaration.getPropertyValue() returns null instead of '' in old Android browsers, so we check if the returned value is not null before calling trim().