### PR TITLE
Make language setting in config override autodetection

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -210,14 +210,18 @@ function initLocales() {
     let preferredLangs = (window.navigator && window.navigator.languages) || [];
     let preferredLang = preferredLangs[0];
 
-    if (preferredLang) {
-        i18next.changeLanguage(preferredLang, (err, t) => {
-            if (err && defaultLang) {
-                i18next.changeLanguage(defaultLang);
+    if (defaultLang) {
+        i18next.changeLanguage(defaultLang, (err, t) => {
+            if (err) {
+                i18next.changeLanguage('en-us');
             }
         });
-    } else if (defaultLang) {
-        i18next.changeLanguage(defaultLang);
+    } else if (preferredLang) {
+        i18next.changeLanguage(preferredLang, (err, t) => {
+            if (err) {
+                i18next.changeLanguage('en-us');
+            }
+        });
     }
 }
 


### PR DESCRIPTION
From what i can see there is 3 options for this:

1) setting.language is the forced language if set (auto-detect / en-us if not set)

2) setting.forcelang (boolean) toggles setting.language to be default or fallback

3) setting.language is fallback, setting.forcelang is the default (if set)