### PR TITLE
added timestamp_placement option to MessageListMessageCompact.vue

### DIFF
--- a/src/components/MessageListMessageCompact.vue
+++ b/src/components/MessageListMessageCompact.vue
@@ -37,6 +37,7 @@
     >
         <div
             v-if="ml.bufferSetting('show_timestamps')"
+            v-bind:style="{float: ml.bufferSetting('timestamp_placement')}"
             class="kiwi-messagelist-time"
         >
             {{ml.formatTime(message.time)}}
@@ -121,7 +122,6 @@ export default {
 
 .kiwi-messagelist-message--compact .kiwi-messagelist-time {
     display: inline-block;
-    float: right;
     font-size: 12px;
 }
 

--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -42,6 +42,7 @@ const stateObj = {
             alert_on: 'highlight',
             timestamp_format: '%H:%M:%S',
             show_timestamps: true,
+            timestamp_placement: 'right',
             scrollback_size: 250,
             show_joinparts: true,
             show_topics: true,


### PR DESCRIPTION
#66

kiwi.state.setting('buffers.timestamp_placement', 'left')

"buffers": {
    "timestamp_placement": "left"
},