### PR TITLE
added formatting_blacklist option to MessageFormatter.js

### DIFF
--- a/src/libs/Message.js
+++ b/src/libs/Message.js
@@ -50,6 +50,7 @@ export default class Message {
         let html = '';
         let blocks = formatIrcMessage(this.message, {
             extras: useExtraFormatting,
+            blacklist: state.setting('buffers.formatting_blacklist'),
         });
 
         blocks.forEach((bl, idx) => {

--- a/src/libs/MessageFormatter.js
+++ b/src/libs/MessageFormatter.js
@@ -250,10 +250,17 @@ export default function parse(inp, _opts) {
 
     while (pos < len) {
         let tok = findTokenAtPosition();
-        if (!tok || (!opts.extras && tok.extra)) {
-            block.content += inp[pos];
-            block.containsContent = true;
-            pos++;
+        let toklen = (tok) ? tok.token.length : 1;
+        if (!tok || (!opts.extras && tok.extra) || opts.blacklist.includes(tok.token)) {
+            // advance token length to allow for blacklisted tokens
+            //   and prevent them matching other tokens
+            // Eg, if ** is disabled; '**word**', char1 gets skipped as ** is disabled,
+            //   then char2 gets matched again as token *
+            for (let i = 0; i < toklen; i++) {
+                block.content += inp[pos];
+                block.containsContent = true;
+                pos++;
+            }
             continue;
         }
 

--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -52,6 +52,7 @@ const stateObj = {
             block_pms: false,
             show_emoticons: true,
             extra_formatting: true,
+            formatting_blacklist: [],
             mute_sound: false,
             hide_message_counts: false,
             default_ban_mask: '*!%i@%h',


### PR DESCRIPTION
kiwi.state.setting('buffers.formatting_blacklist', ['*', '**'])

"buffers": {
"formatting_blacklist": ["*", "**"]
},

#154 