### PR TITLE
Issue 297

### DIFF
--- a/src/components/MessageListMessageCompact.vue
+++ b/src/components/MessageListMessageCompact.vue
@@ -209,7 +209,7 @@ export default {
     .kiwi-messagelist-message--compact .kiwi-messagelist-body {
         float: left;
         width: 100%;
-        margin-left: 3px;
+        margin-left: 0px;
     }
 
     .kiwi-messagelist-message--compact.kiwi-messagelist-message--unread .kiwi-messagelist-body {

--- a/src/components/MessageListMessageCompact.vue
+++ b/src/components/MessageListMessageCompact.vue
@@ -200,6 +200,7 @@ export default {
         width: auto;
         float: left;
         position: static;
+        padding-left: 0;
     }
 
     .kiwi-messagelist-message--compact .kiwi-messagelist-time {
@@ -209,7 +210,7 @@ export default {
     .kiwi-messagelist-message--compact .kiwi-messagelist-body {
         float: left;
         width: 100%;
-        margin-left: 0px;
+        margin-left: 0;
     }
 
     .kiwi-messagelist-message--compact.kiwi-messagelist-message--unread .kiwi-messagelist-body {


### PR DESCRIPTION
This fix aligns the username and message on the compact view for mobile. #297 