### PR TITLE
add api event 'buffer.paste'

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -7,6 +7,7 @@
             'kiwi-wrap--touch': state.ui.is_touch,
         }"
         @click="emitDocumentClick"
+        @paste="emitBufferPaste"
     >
         <link v-bind:href="themeUrl" rel="stylesheet" type="text/css">
 
@@ -282,6 +283,22 @@ export default {
 
                 return null;
             };
+        },
+        emitBufferPaste: function emitBufferPaste(event) {
+            // bail if no buffer is active, or the buffer is hidden by another component
+            if (!this.state.getActiveBuffer() || this.activeComponent !== null) {
+                return;
+            }
+
+            // bail if a sidebar is open
+            if (this.$data.uiState.sidebarOpen) {
+                return;
+            }
+
+            state.$emit('buffer.paste', event);
+
+            event.stopPropagation();
+            event.preventDefault();
         },
         emitDocumentClick: function emitDocumentClick(event) {
             state.$emit('document.clicked', event);

--- a/src/components/utils/IrcInput.vue
+++ b/src/components/utils/IrcInput.vue
@@ -53,7 +53,6 @@ export default Vue.component('irc-input', {
             }
         },
         onPaste: function onPaste(event) {
-            event.stopPropagation();
             event.preventDefault();
 
             let clipboardData = event.clipboardData || window.clipboardData;


### PR DESCRIPTION
only fires if a buffer is active and no sidebar is open
forwards the native ClipboardEvent