### PR TITLE
Remove overflow visible from Nick on hover -  Issue #325 fix

### DIFF
--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -573,10 +573,6 @@ export default {
     cursor: pointer;
 }
 
-.kiwi-messagelist-nick:hover {
-    overflow: visible;
-}
-
 /* Topic changes */
 .kiwi-messagelist-message-topic {
     border-radius: 5px;

--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -573,6 +573,11 @@ export default {
     cursor: pointer;
 }
 
+.kiwi-messagelist-nick:hover {
+    overflow: visible;
+    width: auto;
+}
+
 /* Topic changes */
 .kiwi-messagelist-message-topic {
     border-radius: 5px;

--- a/src/components/MessageListMessageCompact.vue
+++ b/src/components/MessageListMessageCompact.vue
@@ -112,12 +112,12 @@ export default {
     position: absolute;
 }
 
-.kiwi-messagelist-message--compact.kiwi-messagelist-message-nick .kiwi-messagelist-time {
-    margin-right: 10px;
+.kiwi-messagelist-message--compact .kiwi-messagelist-nick:hover {
+    width: auto;
 }
 
-.kiwi-messagelist-message--compact .kiwi-messagelist-message-nick {
-    margin-right: 14px;
+.kiwi-messagelist-message--compact.kiwi-messagelist-message-nick .kiwi-messagelist-time {
+    margin-right: 10px;
 }
 
 .kiwi-messagelist-message--compact .kiwi-messagelist-time {

--- a/static/themes/dark/theme.css
+++ b/static/themes/dark/theme.css
@@ -461,12 +461,12 @@
 }
 
 .kiwi-messagelist-message--highlight{
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: #5a5a5a;
 }
 
 /*When hovering over a users messages */
 .kiwi-messagelist-message--hover{
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: #dedede;
 }
 
 .kiwi-messagelist-message--modern .kiwi-messagelist-body {
@@ -521,7 +521,7 @@
     background: rgba(0,0,0,0.02);
     border: 2px solid #42b992;
     color: #dedede;
-}   
+}
 
 .kiwi-messagelist-message-traffic-join {
     color: #090;
@@ -568,6 +568,10 @@
 }
 .kiwi-messagelist-nick {
     color: #000;
+}
+
+.kiwi-messagelist-message--compact .kiwi-messagelist-nick:hover {
+    background-color: #dedede;
 }
 
 .kiwi-messagelist-time {

--- a/static/themes/default/theme.css
+++ b/static/themes/default/theme.css
@@ -509,6 +509,10 @@
     color: #000;
 }
 
+.kiwi-messagelist-message--compact .kiwi-messagelist-nick:hover {
+    background-color: #f2f2f2;
+}
+
 .kiwi-messagelist-time {
     color: #a0a09f;
 }


### PR DESCRIPTION
- Removed the overflow ; visible property from the MessageList component. Issue #325 (username spacing on hover, safari only) seems to be caused by this. I can see no negative side effect of removing this on other browsers, as nicknames that are very long are not fully shown, even on hover, at present.

#325  Fix.