### PR TITLE
Styling updates to Sidebar and Pinned Icon

### DIFF
--- a/src/components/AppSettings.vue
+++ b/src/components/AppSettings.vue
@@ -316,13 +316,13 @@ export default {
     display: block;
     box-sizing: border-box;
     margin: 20px auto 20px auto;
+}
 
-    h3 {
-        width: 100%;
-        line-height: 45px;
-        padding: 0 10px;
-        box-sizing: border-box;
-    }
+.kiwi-appsettings-block h3 {
+    width: 100%;
+    line-height: 45px;
+    padding: 0 10px;
+    box-sizing: border-box;
 }
 
 .kiwi-appsettings-section {
@@ -346,28 +346,28 @@ export default {
     line-height: 47px;
     text-align: right;
     transition: background 0.3s;
+}
 
-    h2 {
-        padding: 10px 0 11px 20px;
-        width: auto;
-        float: left;
-    }
+.kiwi-appsettings-title h2 {
+    padding: 10px 0 11px 20px;
+    width: auto;
+    float: left;
+}
 
-    a {
-        float: right;
-        position: static;
-        background: none;
-        border: none;
-        padding: 10px 20px;
-        font-size: 1.4em;
-    }
+.kiwi-appsettings-title a {
+    float: right;
+    position: static;
+    background: none;
+    border: none;
+    padding: 10px 20px;
+    font-size: 1.4em;
+}
 
-    i {
-        margin-left: 10px;
-        font-size: 1.5em;
-        float: right;
-        line-height: 47px;
-    }
+.kiwi-appsettings-title i {
+    margin-left: 10px;
+    font-size: 1.5em;
+    float: right;
+    line-height: 47px;
 }
 
 @media screen and (max-width: 769px) {

--- a/src/components/BufferSettings.vue
+++ b/src/components/BufferSettings.vue
@@ -4,17 +4,17 @@
             <h3>{{$t('settings_notify')}}</h3>
             <hr>
             <form class="u-form">
-                <label>
-                    <span>{{$t('settings_notify_all')}}</span>
+                <label class="u-checkbox-wrapper">
                     <input type="radio" name="alert_on" value="message" v-model="settingAlertOn">
+                    <span>{{$t('settings_notify_all')}}</span>
                 </label>
-                <label>
-                    <span>{{$t('settings_notify_mentioned')}}</span>
+                <label class="u-checkbox-wrapper">
                     <input type="radio" name="alert_on" value="highlight" v-model="settingAlertOn">
+                    <span>{{$t('settings_notify_mentioned')}}</span>
                 </label>
-                <label>
-                    <span>{{$t('settings_notify_never')}}</span>
+                <label class="u-checkbox-wrapper">
                     <input type="radio" name="alert_on" value="never" v-model="settingAlertOn">
+                    <span>{{$t('settings_notify_never')}}</span>
                 </label>
             </form>
 

--- a/src/components/ChannelInfo.vue
+++ b/src/components/ChannelInfo.vue
@@ -6,21 +6,21 @@
                 <textarea v-model.lazy="topic" rows="2"></textarea>
             </label>
 
-            <label>
-                <input type="checkbox" v-model="modeM" />
+            <label class="u-checkbox-wrapper">
                 <span>{{$t('channel_moderated')}}</span>
+                <input type="checkbox" v-model="modeM" />
             </label>
-            <label>
-                <input type="checkbox" v-model="modeI" />
+            <label class="u-checkbox-wrapper">
                 <span>{{$t('channel_invite')}}</span>
+                <input type="checkbox" v-model="modeI" />
             </label>
-            <label>
-                <input type="checkbox" v-model="modeT" />
+            <label class="u-checkbox-wrapper">
                 <span>{{$t('channel_moderated_topic')}}</span>
+                <input type="checkbox" v-model="modeT" />
             </label>
-            <label>
-                <input type="checkbox" v-model="modeN" />
+            <label class="u-checkbox-wrapper">
                 <span>{{$t('channel_external')}}</span>
+                <input type="checkbox" v-model="modeN" />
             </label>
             <label>
                 <span>{{$t('password')}}</span>

--- a/src/components/ChannelInfo.vue
+++ b/src/components/ChannelInfo.vue
@@ -129,6 +129,3 @@ export default {
     },
 };
 </script>
-
-<style lang="less">
-</style>

--- a/src/components/Container.vue
+++ b/src/components/Container.vue
@@ -136,7 +136,7 @@ export default {
 
 .kiwi-sidebar {
     position: absolute;
-    right: -443px;
+    right: -100%;
     top: -4px; /* Push the top over the top page border */
     bottom: 0;
     width: 443px;
@@ -157,6 +157,7 @@ export default {
     position: relative;
     border-left-width: 1px;
     border-left-style: solid;
+    max-width: 430px;
 }
 
 .kiwi-container-content {
@@ -229,6 +230,12 @@ export default {
     font-weight: 500;
     line-height: 50px;
     padding: 0 14px;
+}
+
+@media screen and (max-width: 1500px) {
+    .kiwi-container--sidebar-pinned .kiwi-sidebar {
+        max-width: 350px;
+    }
 }
 
 @media screen and (max-width: 769px) {

--- a/src/components/Container.vue
+++ b/src/components/Container.vue
@@ -136,11 +136,11 @@ export default {
 
 .kiwi-sidebar {
     position: absolute;
-    right: -380px;
+    right: -443px;
     top: -4px; /* Push the top over the top page border */
     bottom: 0;
-    width: 380px;
-    max-width: 380px;
+    width: 443px;
+    max-width: 443px;
     z-index: 2;
     transition: right 0.2s, width 0.2s;
     flex: 1;

--- a/src/components/ContainerHeader.vue
+++ b/src/components/ContainerHeader.vue
@@ -194,10 +194,10 @@ export default {
 /* why this hover? */
 .kiwi-header:hover {
     max-height: none;
+}
 
-    .kiwi-header-topic {
-        display: block;
-    }
+.kiwi-header:hover .kiwi-header-topic {
+    display: block;
 }
 
 .kiwi-header-topic {
@@ -245,46 +245,46 @@ export default {
     opacity: 0.9;
     font-weight: 900;
     text-transform: capitalize;
+}
 
-    a {
-        float: left;
-        padding: 0 10px;
-        line-height: 45px;
-        display: block;
-        font-weight: 600;
-        opacity: 0.8;
-        cursor: pointer;
-        transition: all 0.3s;
+.kiwi-header-option a {
+    float: left;
+    padding: 0 10px;
+    line-height: 45px;
+    display: block;
+    font-weight: 600;
+    opacity: 0.8;
+    cursor: pointer;
+    transition: all 0.3s;
+}
 
-        &:hover {
-            opacity: 1;
-        }
-    }
+.kiwi-header-option a:hover {
+    opacity: 1;
+}
 
-    i {
-        margin-right: 10px;
-        font-size: 1.2em;
-        float: left;
-        line-height: 45px;
-    }
+.kiwi-header-option i {
+    margin-right: 10px;
+    font-size: 1.2em;
+    float: left;
+    line-height: 45px;
+}
 
-    &--active {
-        opacity: 1;
+.kiwi-header-option--active {
+    opacity: 1;
+}
 
-        a {
-            opacity: 1;
-        }
-    }
+.kiwi-header-option--active a {
+    opacity: 1;
 }
 
 .kiwi-header-option-leave {
     opacity: 1;
     margin: 0;
     transition: all 0.3s;
+}
 
-    i {
-        margin: 0;
-    }
+.kiwi-header-option-leave i {
+    margin: 0;
 }
 
 .kiwi-header-option-unpinsidebar i {
@@ -297,14 +297,14 @@ export default {
     display: inline-block;
     margin: 0 auto;
     float: right;
+}
 
-    .u-link {
-        font-weight: 600;
-        line-height: 45px;
-        padding: 0 25px;
-        border-radius: 0;
-        transition: all 0.3;
-    }
+.kiwi-header-notjoined .u-link {
+    font-weight: 600;
+    line-height: 45px;
+    padding: 0 25px;
+    border-radius: 0;
+    transition: all 0.3;
 }
 
 .kiwi-header-server-settings {
@@ -315,14 +315,14 @@ export default {
     float: right;
     padding-right: 10px;
     line-height: 46px;
+}
 
-    .u-button {
-        float: right;
-        line-height: 35px;
-        padding: 0 1em;
-        margin: 4px 0;
-        border-radius: 4px;
-    }
+.kiwi-header-server-connection .u-button {
+    float: right;
+    line-height: 35px;
+    padding: 0 1em;
+    margin: 4px 0;
+    border-radius: 4px;
 }
 
 .kiwi-header-options .u-button {
@@ -368,31 +368,27 @@ export default {
         max-height: none;
         padding-left: 0;
         margin-left: 0;
-
-        .kiwi-header-name {
-            line-height: normal;
-            padding-left: 60px;
-        }
     }
 
-    .kiwi-header-option {
-        a {
-            i {
-                margin-right: 0;
-            }
-        }
+    .kiwi-header .kiwi-header-name {
+        line-height: normal;
+        padding-left: 60px;
+    }
 
-        .fa-info {
-            display: block;
-            font-size: 1.5em;
-            padding: 0;
-            opacity: 0.8;
-            line-height: 45px;
-        }
+    .kiwi-header-option a i {
+        margin-right: 0;
+    }
 
-        span {
-            display: none;
-        }
+    .kiwi-header-option .fa-info {
+        display: block;
+        font-size: 1.5em;
+        padding: 0;
+        opacity: 0.8;
+        line-height: 45px;
+    }
+
+    .kiwi-header-option span {
+        display: none;
     }
 
     .kiwi-header-server-connection .u-button {

--- a/src/components/ContainerHeader.vue
+++ b/src/components/ContainerHeader.vue
@@ -357,7 +357,7 @@ export default {
 
 @media screen and (max-width: 769px) {
     .kiwi-container-toggledraw-statebrowser {
-        z-index: 10;
+        z-index: 2;
         border-bottom: none;
     }
 

--- a/src/components/ContainerHeader.vue
+++ b/src/components/ContainerHeader.vue
@@ -14,8 +14,8 @@
                     <a v-if="viewTopic"><i class="fa fa-info" aria-hidden="true"></i> <span class="kiwi-containerheader-hidetext">Hide Topic</span></a>
                     <a v-if="!viewTopic"><i class="fa fa-info" aria-hidden="true"></i> <span class="kiwi-containerheader-hidetext">Display Topic</span></a>
                 </div>
-                <div class="kiwi-header-option kiwi-header-option-nicklist" v-bind:class="{ 'kiwi-header-option-active': uiState.sidebarSection ==='nicklist'}"><a @click="uiState.showNicklist()"><i class="fa fa-users" aria-hidden="true"></i></i> <span>{{$t('person', {count: Object.keys(buffer.users).length})}}</span></a></div>
-                <div class="kiwi-header-option kiwi-header-option-settings" v-bind:class="{ 'kiwi-header-option-active': uiState.sidebarSection ==='settings'}"><a @click="uiState.showBufferSettings()"><i class="fa fa-cog" aria-hidden="true"></i> <span>Channel Settings</span></a></div>
+                <div class="kiwi-header-option kiwi-header-option-nicklist" v-bind:class="{ 'kiwi-header-option--active': uiState.sidebarSection ==='nicklist'}"><a @click="uiState.showNicklist()"><i class="fa fa-users" aria-hidden="true"></i></i> <span>{{$t('person', {count: Object.keys(buffer.users).length})}}</span></a></div>
+                <div class="kiwi-header-option kiwi-header-option-settings" v-bind:class="{ 'kiwi-header-option--active': uiState.sidebarSection ==='settings'}"><a @click="uiState.showBufferSettings()"><i class="fa fa-cog" aria-hidden="true"></i> <span>Channel Settings</span></a></div>
                 <div v-if="uiState.isPinned" class="kiwi-header-option kiwi-header-option-unpinsidebar"><a @click="uiState.unpin()"><i class="fa fa-thumb-tack" aria-hidden="true"></i></a></div>
                 <div class="kiwi-header-option kiwi-header-option-leave"><a @click="closeCurrentBuffer"><i class="fa fa-times" aria-hidden="true"></i></a></div>
             </div>

--- a/src/components/ContainerHeader.vue
+++ b/src/components/ContainerHeader.vue
@@ -14,8 +14,8 @@
                     <a v-if="viewTopic"><i class="fa fa-info" aria-hidden="true"></i> <span class="kiwi-containerheader-hidetext">Hide Topic</span></a>
                     <a v-if="!viewTopic"><i class="fa fa-info" aria-hidden="true"></i> <span class="kiwi-containerheader-hidetext">Display Topic</span></a>
                 </div>
-                <div class="kiwi-header-option kiwi-header-option-nicklist"><a @click="uiState.showNicklist()"><i class="fa fa-users" aria-hidden="true"></i></i> <span>{{$t('person', {count: Object.keys(buffer.users).length})}}</span></a></div>
-                <div class="kiwi-header-option kiwi-header-option-settings"><a @click="uiState.showBufferSettings()"><i class="fa fa-cog" aria-hidden="true"></i> <span>Channel Settings</span></a></div>
+                <div class="kiwi-header-option kiwi-header-option-nicklist" v-bind:class="{ 'kiwi-header-option-active': uiState.sidebarSection ==='nicklist'}"><a @click="uiState.showNicklist()"><i class="fa fa-users" aria-hidden="true"></i></i> <span>{{$t('person', {count: Object.keys(buffer.users).length})}}</span></a></div>
+                <div class="kiwi-header-option kiwi-header-option-settings" v-bind:class="{ 'kiwi-header-option-active': uiState.sidebarSection ==='settings'}"><a @click="uiState.showBufferSettings()"><i class="fa fa-cog" aria-hidden="true"></i> <span>Channel Settings</span></a></div>
                 <div v-if="uiState.isPinned" class="kiwi-header-option kiwi-header-option-unpinsidebar"><a @click="uiState.unpin()"><i class="fa fa-thumb-tack" aria-hidden="true"></i></a></div>
                 <div class="kiwi-header-option kiwi-header-option-leave"><a @click="closeCurrentBuffer"><i class="fa fa-times" aria-hidden="true"></i></a></div>
             </div>

--- a/src/components/ControlInput.vue
+++ b/src/components/ControlInput.vue
@@ -436,18 +436,6 @@ export default {
     border: none;
 }
 
-@media screen and (max-width: 769px) {
-    .kiwi-controlinput {
-        z-index: 0;
-    }
-}
-
-@media screen and (max-width: 500px) {
-    .kiwi-controlinput-user-nick {
-        display: none;
-    }
-}
-
 .kiwi-controlinput-input-wrap {
     width: 100%;
     height: 100%;
@@ -482,6 +470,18 @@ export default {
 
 .kiwi-controlinput-selfuser--open {
     max-height: 300px;
+}
+
+@media screen and (max-width: 769px) {
+    .kiwi-controlinput {
+        z-index: 0;
+    }
+}
+
+@media screen and (max-width: 500px) {
+    .kiwi-controlinput-user-nick {
+        display: none;
+    }
 }
 
 </style>

--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -453,7 +453,7 @@ export default {
 
 .kiwi-container--sidebar-open .kiwi-messagelist::after {
     content: '';
-    z-index: 1;
+    z-index: 2;
     left: 0;
     top: 0;
     width: 100%;

--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -481,13 +481,6 @@ export default {
     border-top: none;
 }
 
-@media screen and (max-width: 700px) {
-    .kiwi-messagelist-message,
-    .kiwi-messageinfo {
-        margin: 0;
-    }
-}
-
 .kiwi-messagelist-message--blur {
     opacity: 0.5;
 }
@@ -619,5 +612,12 @@ export default {
 
 .kiwi-wrap--touch .kiwi-messagelist-message-linkhandle {
     display: none;
+}
+
+@media screen and (max-width: 700px) {
+    .kiwi-messagelist-message,
+    .kiwi-messageinfo {
+        margin: 0;
+    }
 }
 </style>

--- a/src/components/MessageListMessageCompact.vue
+++ b/src/components/MessageListMessageCompact.vue
@@ -145,25 +145,25 @@ export default {
 .kiwi-messagelist-message--compact.kiwi-messagelist-message-traffic {
     margin: 0;
     padding: 1px 0;
+}
 
-    .kiwi-messagelist-body {
-        margin-left: 131px;
-    }
+.kiwi-messagelist-message--compact.kiwi-messagelist-message-traffic .kiwi-messagelist-body {
+    margin-left: 131px;
 }
 
 //Channel Connection's
 .kiwi-messagelist-message--compact.kiwi-messagelist-message-connection {
     text-align: center;
+}
 
-    .kiwi-messagelist-nick,
-    .kiwi-messagelist-time {
-        display: none;
-    }
+.kiwi-messagelist-message--compact.kiwi-messagelist-message-connection .kiwi-messagelist-nick,
+.kiwi-messagelist-message--compact.kiwi-messagelist-message-connection .kiwi-messagelist-time {
+    display: none;
+}
 
-    .kiwi-messagelist-body {
-        display: inline-block;
-        margin-left: auto;
-    }
+.kiwi-messagelist-message--compact.kiwi-messagelist-message-connection .kiwi-messagelist-body {
+    display: inline-block;
+    margin-left: auto;
 }
 
 //Channel topic
@@ -172,12 +172,12 @@ export default {
     border-left: 0;
     border-right: 0;
     margin: 5px 0;
+}
 
-    .kiwi-messagelist-body {
-        padding-right: 0;
-        max-width: 95%;
-        margin-left: 20px;
-    }
+.kiwi-messagelist-message--compact.kiwi-messagelist-message-topic .kiwi-messagelist-body {
+    padding-right: 0;
+    max-width: 95%;
+    margin-left: 20px;
 }
 
 //Repeat messages, remove the time and author name

--- a/src/components/MessageListMessageModern.vue
+++ b/src/components/MessageListMessageModern.vue
@@ -190,19 +190,8 @@ export default {
     display: none;
 }
 
+/* Connection styling */
 .kiwi-messagelist-message--modern.kiwi-messagelist-message-connection {
-    .kiwi-messagelist-modern-left {
-        display: none;
-    }
-
-    .kiwi-messagelist-modern-right {
-        margin-left: 0;
-        padding: 0;
-    }
-}
-
-.kiwi-messagelist-message--modern.kiwi-messagelist-message-connection-connected,
-.kiwi-messagelist-message--modern.kiwi-messagelist-message-connection-disconnected {
     padding: 0;
     box-sizing: border-box;
     margin: 10px auto;
@@ -211,27 +200,32 @@ export default {
     opacity: 1;
     border-left: none;
     text-align: center;
-
-    .kiwi-messagelist-time,
-    .kiwi-messagelist-nick {
-        display: none;
-    }
-
-    .kiwi-messagelist-body {
-        line-height: 30px;
-        font-weight: 100;
-        margin: 0 auto;
-        border-radius: 4px;
-        display: inline-block;
-    }
-
-    .kiwi-messagelist-message {
-        margin-bottom: 0;
-    }
 }
 
-.kiwi-messagelist-message--modern.kiwi-messagelist-message-connection-connected {
-    width: 250px;
+.kiwi-messagelist-message--modern.kiwi-messagelist-message-connection .kiwi-messagelist-time,
+.kiwi-messagelist-message--modern.kiwi-messagelist-message-connection .kiwi-messagelist-nick {
+    display: none;
+}
+
+.kiwi-messagelist-message--modern.kiwi-messagelist-message-connection .kiwi-messagelist-body {
+    line-height: 30px;
+    font-weight: 100;
+    margin: 0 auto;
+    border-radius: 4px;
+    display: inline-block;
+}
+
+.kiwi-messagelist-message--modern.kiwi-messagelist-message-connection .kiwi-messagelist-message {
+    margin-bottom: 0;
+}
+
+.kiwi-messagelist-message--modern.kiwi-messagelist-message-connection .kiwi-messagelist-modern-left {
+    display: none;
+}
+
+.kiwi-messagelist-message--modern.kiwi-messagelist-message-connection .kiwi-messagelist-modern-right {
+    margin-left: 0;
+    padding: 0;
 }
 
 .kiwi-messagelist-message--modern .kiwi-messagelist-body {
@@ -315,7 +309,7 @@ export default {
         margin: 0;
     }
 
-    .kiwi-messagelist-message--modern.kiwi-messagelist-message-connection-connected {
+    .kiwi-messagelist-message--modern.kiwi-messagelist-message-connection {
         padding: 0;
         box-sizing: border-box;
         margin: 0;
@@ -324,20 +318,12 @@ export default {
         width: 100%;
         border-radius: 0;
         opacity: 0.8;
+    }
 
-        .kiwi-messagelist-body {
-            line-height: 50px;
-            font-weight: 600;
-            padding: 0;
-        }
-
-        &.kiwi-messagelist-message--unread {
-            background: red;
-
-            .kiwi-messagelist-body {
-                background: transparent;
-            }
-        }
+    .kiwi-messagelist-message--modern.kiwi-messagelist-message-connection .kiwi-messagelist-body {
+        line-height: 50px;
+        font-weight: 600;
+        padding: 0;
     }
 
     .kiwi-messagelist-message-action .kiwi-messagelist-modern-left {

--- a/src/components/MessageListMessageModern.vue
+++ b/src/components/MessageListMessageModern.vue
@@ -292,10 +292,6 @@ export default {
     margin-bottom: 10px;
 }
 
-.kiwi-messagelist-item:last-of-type {
-    margin-bottom: 10px;
-}
-
 .kiwi-messagelist-message--modern.kiwi-messagelist-message-traffic {
     margin-right: 0;
     padding-left: 60px;

--- a/src/components/NetworkSettings.vue
+++ b/src/components/NetworkSettings.vue
@@ -235,10 +235,10 @@ export default {
 }
 
 .kiwi-networksettings input[type='text'],
-    .kiwi-networksettings input[type='password'],
-    .kiwi-networksettings input[type='email'],
-    .kiwi-networksettings textarea,
-    .kiwi-networksettings .input-text input {
+.kiwi-networksettings input[type='password'],
+.kiwi-networksettings input[type='email'],
+.kiwi-networksettings textarea,
+.kiwi-networksettings .input-text input {
     clear: both;
     width: 100%;
     height: 40px;
@@ -283,18 +283,18 @@ export default {
     width: 100%;
     padding: 20px;
     box-sizing: border-box;
+}
 
-    label {
-        margin: 0;
-    }
+.kiwi-networksettings .kiwi-padded-form-element-container label {
+    margin: 0;
+}
 
-    .input-text {
-        padding-top: 0;
-    }
+.kiwi-networksettings .kiwi-padded-form-element-container .input-text {
+    padding-top: 0;
+}
 
-    &.kiwi-dangerzone {
-        text-align: center;
-    }
+.kiwi-networksettings .kiwi-padded-form-element-container.kiwi-dangerzone {
+    text-align: center;
 }
 
 .kiwi-networksettings-advanced-container {
@@ -378,10 +378,10 @@ export default {
     cursor: pointer;
     padding: 0 10px;
     line-height: 35px;
+}
 
-    &:hover {
-        opacity: 1;
-    }
+.kiwi-networksettings .kiwi-connect-to-newnetwork:hover {
+    opacity: 1;
 }
 
 .kiwi-networksettings-section {
@@ -462,10 +462,10 @@ export default {
     opacity: 0.8;
     margin: 0 auto;
     transition: all 0.3s;
+}
 
-    &:hover {
-        opacity: 1;
-    }
+.kiwi-networksettings-danger .u-button-warning:hover {
+    opacity: 1;
 }
 
 @media screen and (max-width: 769px) {

--- a/src/components/NetworkSettings.vue
+++ b/src/components/NetworkSettings.vue
@@ -235,10 +235,10 @@ export default {
 }
 
 .kiwi-networksettings input[type='text'],
-.kiwi-networksettings input[type='password'],
-.kiwi-networksettings input[type='email'],
-.kiwi-networksettings textarea,
-.kiwi-networksettings .input-text input {
+    .kiwi-networksettings input[type='password'],
+    .kiwi-networksettings input[type='email'],
+    .kiwi-networksettings textarea,
+    .kiwi-networksettings .input-text input {
     clear: both;
     width: 100%;
     height: 40px;

--- a/src/components/Nicklist.vue
+++ b/src/components/Nicklist.vue
@@ -186,13 +186,6 @@ export default {
     width: 250px;
 }
 
-@media screen and (max-width: 759px) {
-    .kiwi-sidebar.kiwi-sidebar-section-nicklist {
-        width: 100%;
-        max-width: none;
-    }
-}
-
 .kiwi-nicklist {
     overflow: hidden;
     box-sizing: border-box;
@@ -216,12 +209,12 @@ export default {
     padding: 0.5em 10px;
     cursor: default;
     box-sizing: border-box;
+}
 
-    span {
-        font-weight: 600;
-        width: 100%;
-        text-align: center;
-    }
+.kiwi-nicklist-usercount span {
+    font-weight: 600;
+    width: 100%;
+    text-align: center;
 }
 
 .kiwi-nicklist-info {
@@ -236,32 +229,32 @@ export default {
     text-align: center;
     display: flex;
     flex-direction: column;
+}
 
-    input {
-        text-align: left;
-        float: left;
-        width: 100%;
-        border: none;
-        padding: 0 1em;
-        height: 43px;
-        line-height: 43px;
-        font-weight: normal;
-        flex: 1;
-        background: 0 0;
-        outline: 0;
-    }
+.kiwi-nicklist-info input {
+    text-align: left;
+    float: left;
+    width: 100%;
+    border: none;
+    padding: 0 1em;
+    height: 43px;
+    line-height: 43px;
+    font-weight: normal;
+    flex: 1;
+    background: 0 0;
+    outline: 0;
+}
 
-    .fa.fa-search {
-        position: absolute;
-        top: 50%;
-        margin-top: -0.5em;
-        color: #000;
-        opacity: 0.5;
-        line-height: normal;
-        font-size: 1.2em;
-        right: 20px;
-        margin-right: 0;
-    }
+.kiwi-nicklist-info .fa.fa-search {
+    position: absolute;
+    top: 50%;
+    margin-top: -0.5em;
+    color: #000;
+    opacity: 0.5;
+    line-height: normal;
+    font-size: 1.2em;
+    right: 20px;
+    margin-right: 0;
 }
 
 .kiwi-nicklist-users {
@@ -309,6 +302,13 @@ export default {
 .kiwi-nicklist-user-nick {
     font-weight: bold;
     cursor: pointer;
+}
+
+@media screen and (max-width: 759px) {
+    .kiwi-sidebar.kiwi-sidebar-section-nicklist {
+        width: 100%;
+        max-width: none;
+    }
 }
 
 </style>

--- a/src/components/Nicklist.vue
+++ b/src/components/Nicklist.vue
@@ -307,7 +307,7 @@ export default {
 @media screen and (max-width: 759px) {
     .kiwi-sidebar.kiwi-sidebar-section-nicklist {
         width: 100%;
-        max-width: none;
+        max-width: 380px;
     }
 }
 

--- a/src/components/NotConnected.vue
+++ b/src/components/NotConnected.vue
@@ -110,11 +110,11 @@ export default {
     display: inline-block;
     width: 100%;
     margin: 0 0 1em 0;
+}
 
-    i {
-        font-size: 4em;
-        cursor: default;
-    }
+.kiwi-notconnected-bigicon i {
+    font-size: 4em;
+    cursor: default;
 }
 
 .kiwi-notconnected-caption {
@@ -141,17 +141,17 @@ export default {
     margin: 0 0.8em;
     cursor: pointer;
     transition: all 0.3s;
+}
 
-    &:hover {
-        transition: all 0.2s;
-    }
+.kiwi-notconnected-button:hover {
+    transition: all 0.2s;
+}
 
-    i {
-        float: left;
-        font-size: 1.6em;
-        line-height: 0.8em;
-        margin-right: 0.4em;
-    }
+.kiwi-notconnected-button i {
+    float: left;
+    font-size: 1.6em;
+    line-height: 0.8em;
+    margin-right: 0.4em;
 }
 
 .kiwi-notconnected-button-settings {
@@ -160,10 +160,10 @@ export default {
     display: block;
     max-width: 160px;
     margin: 1em auto;
+}
 
-    i {
-        line-height: 1em;
-    }
+.kiwi-notconnected-button-settings i {
+    line-height: 1em;
 }
 
 @media screen and (max-width: 1024px) {

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -216,11 +216,9 @@ export default {
     overflow: hidden;
     z-index: 10;
 
-    /* Users Styling */
-
-    .kiwi-sidebar-section-user {
-        max-width: none;
-        width: auto;
+    .sidebar.kiwi-sidebar-section-settings {
+        width: 500px;
+        max-width: 500px;
     }
 }
 

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -4,7 +4,7 @@
             <template v-if="buffer.isChannel()">
 
                 <span v-if="uiState.isOpen" class="kiwi-sidebar-options">
-                    <div v-if="uiState.canPin" @click="uiState.pin()" class="kiwi-pin-sidebar-icon">
+                    <div v-if="uiState.canPin" @click="uiState.pin()" class="kiwi-sidebar-pin">
                         <i class="fa fa-thumb-tack" aria-hidden="true"></i>
                     </div>
                     <div @click="uiState.close()" class="kiwi-close-sidebar">
@@ -235,7 +235,7 @@ export default {
     line-height: 50px;
     vertical-align: top;
 
-    .kiwi-pin-sidebar-icon {
+    .kiwi-sidebar-pin {
         position: absolute;
         padding: 0 10px;
         height: 100%;

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -28,12 +28,30 @@
                                 <h3>{{$t('side_settings')}}</h3>
                                 <hr>
                                 <form class="u-form">
-                                    <label class="kiwi-checkbox-holder"><input type="checkbox" v-model="settingShowJoinParts"> <span>{{$t('side_joins')}}</span></label>
-                                    <label class="kiwi-checkbox-holder"><input type="checkbox" v-model="settingShowTopics"> <span>{{$t('side_topics')}}</span></label>
-                                    <label class="kiwi-checkbox-holder"><input type="checkbox" v-model="settingShowNickChanges"> <span>{{$t('side_nick_changes')}}</span></label>
-                                    <label class="kiwi-checkbox-holder"><input type="checkbox" v-model="settingShowModeChanges"> <span>{{$t('side_mode_changes')}}</span></label>
-                                    <label class="kiwi-checkbox-holder"><input type="checkbox" v-model="settingExtraFormatting"> <span>{{$t('side_formatting')}}</span></label>
-                                    <label class="kiwi-checkbox-holder"><input type="checkbox" v-model="settingColouredNicklist"> <span>{{$t('side_colours')}}</span></label>
+                                    <label class="u-checkbox-wrapper">
+                                        <span>{{$t('side_joins')}}</span>
+                                        <input type="checkbox" v-model="settingShowJoinParts">
+                                    </label>
+                                    <label class="u-checkbox-wrapper">
+                                        <span>{{$t('side_topics')}}</span>
+                                        <input type="checkbox" v-model="settingShowTopics">
+                                    </label>
+                                    <label class="u-checkbox-wrapper">
+                                        <span>{{$t('side_nick_changes')}}</span>
+                                        <input type="checkbox" v-model="settingShowNickChanges">
+                                    </label>
+                                    <label class="u-checkbox-wrapper">
+                                        <span>{{$t('side_mode_changes')}}</span>
+                                        <input type="checkbox" v-model="settingShowModeChanges">
+                                    </label>
+                                    <label class="u-checkbox-wrapper">
+                                        <span>{{$t('side_formatting')}}</span>
+                                        <input type="checkbox" v-model="settingExtraFormatting">
+                                    </label>
+                                    <label class="u-checkbox-wrapper">
+                                        <span>{{$t('side_colours')}}</span>
+                                        <input type="checkbox" v-model="settingColouredNicklist">
+                                    </label>
                                 </form>
                             </div>
                         </tabbed-tab>
@@ -294,22 +312,6 @@ export default {
 
 .kiwi-channelbanlist-empty {
     margin-top: 10px;
-}
-
-.kiwi-checkbox-holder {
-    position: relative;
-    padding-left: 30px;
-
-    input[type="checkbox"] {
-        position: absolute;
-        margin: 0;
-        top: 2px;
-        left: 0;
-    }
-
-    label {
-        margin-right: 0;
-    }
 }
 
 @media screen and (max-width: 769px) {

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -3,13 +3,12 @@
         <template v-if="buffer">
             <template v-if="buffer.isChannel()">
 
-                <span class="kiwi-sidebar-options">
-                    <div v-if="uiState.isOpen">
-                        <i v-if="uiState.canPin" class="fa fa-thumb-tack" aria-hidden="true" @click="uiState.pin()"></i>
-                        <div @click="uiState.close()">
-                            {{$t('close')}}
-                            <i class="fa fa-times" aria-hidden="true"></i>
-                        </div>
+                <span v-if="uiState.isOpen" class="kiwi-sidebar-options">
+                    <div v-if="uiState.canPin" @click="uiState.pin()" class="kiwi-pin-sidebar-icon">
+                        <i class="fa fa-thumb-tack" aria-hidden="true"></i>
+                    </div>
+                    <div @click="uiState.close()" class="kiwi-close-sidebar">
+                        {{$t('close')}}<i class="fa fa-times" aria-hidden="true"></i>
                     </div>
                 </span>
 
@@ -228,22 +227,35 @@ export default {
 .kiwi-sidebar-options {
     display: block;
     cursor: pointer;
-    padding: 0 10px;
-    color: #fff;
     font-weight: 600;
     width: 100%;
     position: relative;
     box-sizing: border-box;
     text-transform: uppercase;
     line-height: 50px;
-    text-align: right;
     transition: background 0.3s;
+    vertical-align: top;
 
-    i {
-        margin-left: 10px;
-        font-size: 1.5em;
-        float: right;
-        line-height: 47px;
+    .kiwi-pin-sidebar-icon {
+        position: absolute;
+        padding: 0 10px;
+        height: 100%;
+        line-height: 52px;
+        z-index: 1;
+    }
+
+    .kiwi-close-sidebar {
+        width: 100%;
+        display: inline-block;
+        padding: 0 20px 0 40px;
+        text-align: right;
+        box-sizing: border-box;
+
+        i {
+            margin-left: 10px;
+            font-size: 1.5em;
+            line-height: 47px;
+        }
     }
 }
 

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -7,7 +7,7 @@
                     <div v-if="uiState.canPin" @click="uiState.pin()" class="kiwi-sidebar-pin">
                         <i class="fa fa-thumb-tack" aria-hidden="true"></i>
                     </div>
-                    <div @click="uiState.close()" class="kiwi-close-sidebar">
+                    <div @click="uiState.close()" class="kiwi-sidebar-close">
                         {{$t('close')}}<i class="fa fa-times" aria-hidden="true"></i>
                     </div>
                 </span>
@@ -233,11 +233,18 @@ export default {
     flex-direction: column;
     overflow: hidden;
     z-index: 10;
+}
 
-    .sidebar.kiwi-sidebar-section-settings {
-        width: 500px;
-        max-width: 500px;
-    }
+.kiwi-sidebar.kiwi-sidebar-section-settings {
+    width: 500px;
+    max-width: 500px;
+}
+
+.kiwi-sidebar .u-form textarea {
+    min-width: 100%;
+    max-width: 100%;
+    min-height: 80px;
+    resize: vertical;
 }
 
 .kiwi-sidebar-options {
@@ -250,54 +257,47 @@ export default {
     text-transform: uppercase;
     line-height: 50px;
     vertical-align: top;
+}
 
-    .kiwi-sidebar-pin {
-        position: absolute;
-        padding: 0 10px;
-        height: 100%;
-        line-height: 52px;
-        z-index: 1;
-        transition: background 0.3s;
-    }
+.kiwi-sidebar-options .kiwi-sidebar-pin {
+    position: absolute;
+    padding: 0 10px;
+    height: 100%;
+    line-height: 52px;
+    z-index: 1;
+    transition: background 0.3s;
+}
 
-    .kiwi-close-sidebar {
-        width: 100%;
-        display: inline-block;
-        padding: 0 20px 0 40px;
-        text-align: right;
-        box-sizing: border-box;
-        transition: background 0.3s;
+.kiwi-sidebar-options .kiwi-sidebar-close {
+    width: 100%;
+    display: inline-block;
+    padding: 0 20px 0 40px;
+    text-align: right;
+    box-sizing: border-box;
+    transition: background 0.3s;
+}
 
-        i {
-            margin-left: 10px;
-            font-size: 1.5em;
-            line-height: 47px;
-        }
-    }
+.kiwi-sidebar-options .kiwi-sidebar-close i {
+    margin-left: 10px;
+    font-size: 1.5em;
+    line-height: 47px;
 }
 
 .kiwi-sidebar-buffersettings {
     overflow: hidden;
     height: 100%;
+}
 
-    .u-tabbed-content {
-        padding: 1em;
-    }
+.kiwi-sidebar-buffersettings .u-tabbed-content {
+    padding: 1em;
 }
 
 .kiwi-sidebar-settings {
     margin-bottom: 20px;
-
-    label {
-        display: block;
-    }
 }
 
-.kiwi-sidebar .u-form textarea {
-    min-width: 100%;
-    max-width: 100%;
-    min-height: 80px;
-    resize: vertical;
+.kiwi-sidebar-settings label {
+    display: block;
 }
 
 @keyframes settingstransition {
@@ -317,11 +317,11 @@ export default {
 @media screen and (max-width: 769px) {
     .kiwi-sidebar .u-tabbed-view-tab {
         width: 100%;
+    }
 
-        &.u-tabbed-view-tab--active {
-            border-bottom: 3px solid #42b992;
-            margin-bottom: 0;
-        }
+    .kiwi-sidebar .u-tabbed-view-tab.u-tabbed-view-tab--active {
+        border-bottom: 3px solid #42b992;
+        margin-bottom: 0;
     }
 
     .kiwi-sidebar .u-form input[type="checkbox"] {
@@ -345,10 +345,10 @@ export default {
     .kiwi-channelbanlist {
         float: left;
         width: 100%;
+    }
 
-        .kiwi-channelbanlist-table {
-            margin-top: 30px;
-        }
+    .kiwi-channelbanlist-table {
+        margin-top: 30px;
     }
 
     .kiwi-channelbanlist .u-form {

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -29,12 +29,12 @@
                                 <h3>{{$t('side_settings')}}</h3>
                                 <hr>
                                 <form class="u-form">
-                                    <label><input type="checkbox" v-model="settingShowJoinParts"> <span>{{$t('side_joins')}}</span></label>
-                                    <label><input type="checkbox" v-model="settingShowTopics"> <span>{{$t('side_topics')}}</span></label>
-                                    <label><input type="checkbox" v-model="settingShowNickChanges"> <span>{{$t('side_nick_changes')}}</span></label>
-                                    <label><input type="checkbox" v-model="settingShowModeChanges"> <span>{{$t('side_mode_changes')}}</span></label>
-                                    <label><input type="checkbox" v-model="settingExtraFormatting"> <span>{{$t('side_formatting')}}</span></label>
-                                    <label><input type="checkbox" v-model="settingColouredNicklist"> <span>{{$t('side_colours')}}</span></label>
+                                    <label class="kiwi-checkbox-holder"><input type="checkbox" v-model="settingShowJoinParts"> <span>{{$t('side_joins')}}</span></label>
+                                    <label class="kiwi-checkbox-holder"><input type="checkbox" v-model="settingShowTopics"> <span>{{$t('side_topics')}}</span></label>
+                                    <label class="kiwi-checkbox-holder"><input type="checkbox" v-model="settingShowNickChanges"> <span>{{$t('side_nick_changes')}}</span></label>
+                                    <label class="kiwi-checkbox-holder"><input type="checkbox" v-model="settingShowModeChanges"> <span>{{$t('side_mode_changes')}}</span></label>
+                                    <label class="kiwi-checkbox-holder"><input type="checkbox" v-model="settingExtraFormatting"> <span>{{$t('side_formatting')}}</span></label>
+                                    <label class="kiwi-checkbox-holder"><input type="checkbox" v-model="settingColouredNicklist"> <span>{{$t('side_colours')}}</span></label>
                                 </form>
                             </div>
                         </tabbed-tab>
@@ -283,6 +283,22 @@ export default {
 
 .kiwi-channelbanlist-empty {
     margin-top: 10px;
+}
+
+.kiwi-checkbox-holder {
+    position: relative;
+    padding-left: 30px;
+
+    input[type="checkbox"] {
+        position: absolute;
+        margin: 0;
+        top: 2px;
+        left: 0;
+    }
+
+    label {
+        margin-right: 0;
+    }
 }
 
 @media screen and (max-width: 769px) {

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -233,7 +233,6 @@ export default {
     box-sizing: border-box;
     text-transform: uppercase;
     line-height: 50px;
-    transition: background 0.3s;
     vertical-align: top;
 
     .kiwi-pin-sidebar-icon {
@@ -242,6 +241,7 @@ export default {
         height: 100%;
         line-height: 52px;
         z-index: 1;
+        transition: background 0.3s;
     }
 
     .kiwi-close-sidebar {
@@ -250,6 +250,7 @@ export default {
         padding: 0 20px 0 40px;
         text-align: right;
         box-sizing: border-box;
+        transition: background 0.3s;
 
         i {
             margin-left: 10px;

--- a/src/components/StateBrowser.vue
+++ b/src/components/StateBrowser.vue
@@ -27,8 +27,6 @@
             Kiwi Settings <i class="fa fa-cog" aria-hidden="true"></i>
         </div>
 
-        <hr>
-
         <div class="kiwi-statebrowser-tools">
             <div v-for="el in pluginUiElements" v-rawElement="el" class="kiwi-statebrowser-tool"></div>
         </div>

--- a/src/components/StateBrowser.vue
+++ b/src/components/StateBrowser.vue
@@ -199,20 +199,20 @@ export default {
     letter-spacing: 1px;
     transition: all 0.3s;
     margin-bottom: 10px;
+}
 
-    &:hover {
-        opacity: 1;
-    }
+.kiwi-statebrowser-appsettings:hover {
+    opacity: 1;
+}
 
-    span {
-        font-weight: 600;
-    }
+.kiwi-statebrowser-appsettings span {
+    font-weight: 600;
+}
 
-    i {
-        float: right;
-        line-height: 35px;
-        font-size: 1.2em;
-    }
+.kiwi-statebrowser-appsettings i {
+    float: right;
+    line-height: 35px;
+    font-size: 1.2em;
 }
 
 .kiwi-statebrowser-usermenu {
@@ -241,10 +241,10 @@ export default {
     padding: 0 10px;
     font-size: 0.8em;
     margin-bottom: 10px;
+}
 
-    p {
-        margin-bottom: 0;
-    }
+.kiwi-statebrowser-usermenu-body p {
+    margin-bottom: 0;
 }
 
 /* Add network button */

--- a/src/components/UserBox.vue
+++ b/src/components/UserBox.vue
@@ -264,12 +264,9 @@ export default {
 </script>
 
 <style lang="less">
-.kiwi-sidebar-userbox {
+.kiwi-sidebar.kiwi-sidebar-section-user {
     right: 0;
     width: 380px;
-    max-width: none;
-    height: 100%;
-    overflow-y: scroll;
 }
 
 .kiwi-userbox {

--- a/src/components/UserBox.vue
+++ b/src/components/UserBox.vue
@@ -400,10 +400,10 @@ export default {
     border: none;
     line-height: 2.8em;
     font-size: 1em;
+}
 
-    i {
-        margin-right: 0.3em;
-    }
+.kiwi-userbox-opaction i {
+    margin-right: 0.3em;
 }
 
 .kiwi-userbox-actions a {
@@ -427,11 +427,11 @@ export default {
     display: flex;
     flex-direction: row;
     justify-content: center;
+}
 
-    span {
-        /* This fixes a vertical align issue between the checkbox and span */
-        float: right;
-    }
+.kiwi-userbox-ignoreuser span {
+    /* This fixes a vertical align issue between the checkbox and span */
+    float: right;
 }
 
 @media screen and (max-width: 769px) {

--- a/src/res/globalStyle.css
+++ b/src/res/globalStyle.css
@@ -66,7 +66,8 @@ div {
 }
 
 /* Style all form inputs */
-.u-form input[type='checkbox'] {
+.u-form input[type='checkbox'],
+.u-form input[type='radio'] {
     float: left;
     -webkit-appearance: none;
     -moz-appearance: none;
@@ -81,7 +82,8 @@ div {
     margin-right: 5px;
 }
 
-.u-form input[type='checkbox']::after {
+.u-form input[type='checkbox']::after,
+.u-form input[type='radio']::after {
     position: absolute;
     content: '';
     left: 1px;
@@ -93,7 +95,8 @@ div {
     opacity: 0;
 }
 
-.u-form input[type='checkbox']:checked::after {
+.u-form input[type='checkbox']:checked::after,
+.u-form input[type='radio']:checked::after {
     position: absolute;
     content: '';
     left: 1px;
@@ -126,6 +129,23 @@ div {
     overflow-x: hidden;
     overflow-y: auto;
     max-width: none;
+}
+
+.u-checkbox-wrapper {
+    position: relative;
+    padding-left: 30px;
+}
+
+.u-checkbox-wrapper input[type="checkbox"],
+.u-checkbox-wrapper input[type="radio"] {
+    position: absolute;
+    margin: 0;
+    top: 2px;
+    left: 0;
+}
+
+.u-checkbox-wrapper label {
+    margin-right: 0;
 }
 
 .u-form .u-submit {

--- a/static/themes/dark/theme.css
+++ b/static/themes/dark/theme.css
@@ -351,7 +351,8 @@
 }
 
 .kiwi-header-option-topic.kiwi-header-option--active,
-.kiwi-header-option-leave a:hover {
+.kiwi-header-option-leave a:hover,
+.kiwi-header-option-unpinsidebar:hover {
     background-color: #d16c6c;
     color: #dedede;
 }
@@ -888,10 +889,6 @@
 }
 
 .kiwi-network-name-options .kiwi--collapse {
-    background: #d16c6c;
-}
-
-.kiwi-statebrowser-channel-leave:hover{
     background: #d16c6c;
 }
 

--- a/static/themes/dark/theme.css
+++ b/static/themes/dark/theme.css
@@ -131,16 +131,19 @@
     max-width: none;
 }
 
-.u-form input[type='checkbox'] {
+.u-form input[type='checkbox'],
+.u-form input[type='radio'] {
     border: 2px solid #000;
     background-color: #ffffff;
 }
 
-.u-form input[type='checkbox']:after {
+.u-form input[type='checkbox']:after,
+.u-form input[type='radio']:after {
     background: #42b992;
 }
 
-.u-form input[type='checkbox']:after {
+.u-form input[type='checkbox']:after,
+.u-form input[type='radio']:after {
     background: #42b992;
 }
 

--- a/static/themes/dark/theme.css
+++ b/static/themes/dark/theme.css
@@ -496,8 +496,24 @@
     background: #1e1e1e;
 }
 
+/* Sidebar ( Sidebar.vue ) */
+.kiwi-sidebar-options {
+    background-color: #42b992;
+    color: #dedede;
+}
+.kiwi-pin-sidebar-icon {
+    border-right: 1px solid #fff;
+    background: #42b992;
+}
+.kiwi-pin-sidebar-icon:hover{
+    background: #62d0ac;
+}
+
+.kiwi-sidebar-options .kiwi-close-sidebar:hover {
+    background: #d16c6c;
+}
 .kiwi-container--sidebar-pinned .kiwi-sidebar {
-    border-color: #464646;
+    border-color: #b2b2b2;
 }
 
 .kiwi-sidebar .u-form label input[type="text"],
@@ -801,15 +817,7 @@
     font-weight: 900;
 }
 
-/* Sidebar ( Sidebar.vue ) */
-.kiwi-sidebar-options {
-    background-color: #42b992;
-    color: #dedede;
-}
 
-.kiwi-sidebar-options:hover {
-    background: #d16c6c;
-}
 
 /* Statebrowser - Left sidebar ( StateBrowser.vue ) */
 .kiwi-statebrowser {

--- a/static/themes/dark/theme.css
+++ b/static/themes/dark/theme.css
@@ -501,11 +501,11 @@
     background-color: #42b992;
     color: #dedede;
 }
-.kiwi-pin-sidebar-icon {
+.kiwi-sidebar-pin {
     border-right: 1px solid #fff;
     background: #42b992;
 }
-.kiwi-pin-sidebar-icon:hover{
+.kiwi-sidebar-pin:hover {
     background: #62d0ac;
 }
 

--- a/static/themes/dark/theme.css
+++ b/static/themes/dark/theme.css
@@ -513,7 +513,7 @@
     background: #62d0ac;
 }
 
-.kiwi-sidebar-options .kiwi-close-sidebar:hover {
+.kiwi-sidebar-options .kiwi-sidebar-close:hover {
     background: #d16c6c;
 }
 .kiwi-container--sidebar-pinned .kiwi-sidebar {
@@ -1070,15 +1070,6 @@
 
 .kiwi-statebrowser-newchannel-inputwrap--focus {
     opacity: 1;
-}
-
-.kiwi-statebrowser-usermenu-body .close-icon {
-    background-color: #fc6262;
-    color: #dedede;
-}
-
-.kiwi-statebrowser-usermenu-body .close-icon:hover {
-    background-color: #fe7575;
 }
 
 .kiwi-statebrowser-switcher a:first-of-type {

--- a/static/themes/dark/theme.css
+++ b/static/themes/dark/theme.css
@@ -313,7 +313,7 @@
 }
 
 .kiwi-header-topic {
-    border-top: 2px solid #42b992;
+    border-top: 1px solid #42b992;
     border-bottom: 1px solid #42b992;
     color: #dedede;
 }
@@ -407,7 +407,6 @@
 
 .kiwi-controlinput-active-tool {
     background: #f6f6f6;
-    border: 1px solid #ddd;
 }
 
 .kiwi-messagelist {
@@ -484,7 +483,7 @@
 
 .kiwi-messagelist-message.kiwi-messagelist-message-connection-connected .kiwi-messagelist-body {
     background-color: #42b992;
-    color: #dedede;
+    color: #fff;
 }
 
 .kiwi-messagelist-message.kiwi-messagelist-message-connection-disconnected .kiwi-messagelist-body {
@@ -767,8 +766,11 @@
 /* Self User ( SelfUser.vue ) */
 .kiwi-controlinput-selfuser {
     background: #201F1F;
-    border: 1px solid #ddd;
     color: #dedede;
+}
+
+.kiwi-controlinput-selfuser.kiwi-controlinput-selfuser--open {
+    border: 1px solid #ddd;
 }
 
 .kiwi-selfuser-actions {

--- a/static/themes/default/theme.css
+++ b/static/themes/default/theme.css
@@ -624,7 +624,7 @@
     background: #62d0ac;
 }
 
-.kiwi-sidebar-options .kiwi-close-sidebar:hover {
+.kiwi-sidebar-options .kiwi-sidebar-close:hover {
     background: #d16c6c;
 }
 .kiwi-container--sidebar-pinned .kiwi-sidebar {
@@ -852,13 +852,6 @@
 }
 .kiwi-statebrowser-newchannel-inputwrap--focus {
     opacity: 1;
-}
-.kiwi-statebrowser-usermenu-body .close-icon {
-    background-color: #fc6262;
-    color: #fff;
-}
-.kiwi-statebrowser-usermenu-body .close-icon:hover {
-    background-color: #fe7575;
 }
 
 .kiwi-statebrowser-nonetworks {

--- a/static/themes/default/theme.css
+++ b/static/themes/default/theme.css
@@ -610,12 +610,22 @@
     background-color: #42b992;
     color: #fff;
 }
-.kiwi-sidebar-options:hover {
+.kiwi-pin-sidebar-icon {
+    border-right: 1px solid #fff;
+    background: #42b992;
+    transition: all 0.3s;
+}
+.kiwi-pin-sidebar-icon:hover{
+    background: #62d0ac;
+}
+
+.kiwi-sidebar-options .kiwi-close-sidebar:hover {
     background: #d16c6c;
 }
 .kiwi-container--sidebar-pinned .kiwi-sidebar {
     border-color: #b2b2b2;
 }
+
 
 /* Channel Banlist ( Channelbanlist.vue ) */
 .kiwi-channelbanlist-table tr {

--- a/static/themes/default/theme.css
+++ b/static/themes/default/theme.css
@@ -610,11 +610,11 @@
     background-color: #42b992;
     color: #fff;
 }
-.kiwi-pin-sidebar-icon {
+.kiwi-sidebar-pin{
     border-right: 1px solid #fff;
     background: #42b992;
 }
-.kiwi-pin-sidebar-icon:hover{
+.kiwi-sidebar-pin:hover{
     background: #62d0ac;
 }
 

--- a/static/themes/default/theme.css
+++ b/static/themes/default/theme.css
@@ -258,11 +258,6 @@
     opacity: 1;
 }
 
-/* Remove the border from the un-pin icon */
-.kiwi-header-option-unpinsidebar {
-    border-left: none;
-}
-
 /* Leave channel */
 .kiwi-header-option-leave a:hover,
 .kiwi-header-option-unpinsidebar a:hover {

--- a/static/themes/default/theme.css
+++ b/static/themes/default/theme.css
@@ -238,21 +238,20 @@
     border-left: 1px solid rgba(0, 0, 0, 0.2);
 }
 .kiwi-header-option a:hover,
-.kiwi-header-option--active:hover a,
-.kiwi-header-option.kiwi-header-option-active {
+.kiwi-header-option--active,
+.kiwi-header-option--active:hover a{
     background-color: #42b992;
     color: #fff;
     opacity: 1;
 }
 
-.kiwi-header-option--active,
-.kiwi-header-option.kiwi-header-option-active {
+.kiwi-header-option--active {
     border-left: none;
     opacity: 1;
 }
 
 /* For active buttons, since they are not being hovered, we need to set the child element opacity to 1 */
-.kiwi-header-option.kiwi-header-option-active a{
+.kiwi-header-option-active a{
     opacity: 1;
 }
 

--- a/static/themes/default/theme.css
+++ b/static/themes/default/theme.css
@@ -275,9 +275,10 @@
 
 .kiwi-messagelist-message--compact.kiwi-messagelist-message-topic,
 .kiwi-messagelist-message--modern.kiwi-messagelist-message-topic {
-    border-top: 2px solid #42b992;
+    border-top: 1px solid #42b992;
     border-bottom: 1px solid #42b992;
     color: #5f5f5f;
+    background: #f5f5f5;
 }
 
 .kiwi-messagelist-message--modern.kiwi-messagelist-message-topic.kiwi-messagelist-message--unread {
@@ -286,6 +287,10 @@
 
 .kiwi-messagelist-message--modern.kiwi-messagelist-message--authorrepeat.kiwi-messagelist-message-topic {
     border-top: 2px solid #42b992;
+}
+
+.kiwi-messagelist-message--modern.kiwi-messagelist-message-topic {
+  border: 2px solid #42b992;
 }
 
 .kiwi-header-buffersettings {
@@ -380,7 +385,6 @@
 
 .kiwi-controlinput-active-tool {
     background: #f6f6f6;
-    border: 1px solid #ddd;
 }
 
 /* Message list - Standard messages ( MessageList.vue ) */
@@ -455,12 +459,6 @@
     color: #fff;
 }
 
-/* Topic Styling */
-.kiwi-messagelist-message-topic {
-    background: rgba(0,0,0,0.02);
-    border: 2px solid #42b992;
-}
-
 .kiwi-messagelist-message-traffic-join {
     color: #090;
 }
@@ -514,10 +512,6 @@
 
 .kiwi-messagelist-message--modern.kiwi-messagelist-message--authorrepeat {
   border-top: none;
-}
-
-.kiwi-messagelist-message--modern.kiwi-messagelist-message-topic {
-  border-bottom: 2px solid #42b992;
 }
 
 
@@ -669,6 +663,9 @@
 /* Self User ( SelfUser.vue ) */
 .kiwi-controlinput-selfuser {
     background: #fff;
+}
+
+.kiwi-controlinput-selfuser.kiwi-controlinput-selfuser--open {
     border: 1px solid #ddd;
 }
 

--- a/static/themes/default/theme.css
+++ b/static/themes/default/theme.css
@@ -613,7 +613,6 @@
 .kiwi-pin-sidebar-icon {
     border-right: 1px solid #fff;
     background: #42b992;
-    transition: all 0.3s;
 }
 .kiwi-pin-sidebar-icon:hover{
     background: #62d0ac;

--- a/static/themes/default/theme.css
+++ b/static/themes/default/theme.css
@@ -108,14 +108,17 @@
 }
 
 /* Checkbox Styling */
-.u-form input[type='checkbox'] {
+.u-form input[type='checkbox'],
+.u-form input[type='radio'] {
     border: 2px solid #000;
     background-color: #fff;
 }
-.u-form input[type='checkbox']:after {
+.u-form input[type='checkbox']:after,
+.u-form input[type='radio']:after {
     background: #42b992;
 }
-.u-form input[type='checkbox']:after {
+.u-form input[type='checkbox']:after,
+.u-form input[type='radio']:after {
     background: #42b992;
 }
 

--- a/static/themes/default/theme.css
+++ b/static/themes/default/theme.css
@@ -238,20 +238,31 @@
     border-left: 1px solid rgba(0, 0, 0, 0.2);
 }
 .kiwi-header-option a:hover,
-.kiwi-header-option--active a,
+.kiwi-header-option--active:hover a,
 .kiwi-header-option.kiwi-header-option-active {
     background-color: #42b992;
     color: #fff;
     opacity: 1;
 }
-.kiwi-header-option--active {
-    border-left: 1px solid #42b992;
+
+.kiwi-header-option--active,
+.kiwi-header-option.kiwi-header-option-active {
+    border-left: none;
+    opacity: 1;
 }
-.kiwi-header-option-topic.kiwi-header-option--active,
+
+/* For active buttons, since they are not being hovered, we need to set the child element opacity to 1 */
+.kiwi-header-option.kiwi-header-option-active a{
+    opacity: 1;
+}
+
+/* Leave channel */
 .kiwi-header-option-leave a:hover {
     background-color: #d16c6c;
     color: #fff;
 }
+
+
 
 /* The link to click if the user has not joined this channel */
 .kiwi-header .kiwi-header-notjoined .u-link {

--- a/static/themes/default/theme.css
+++ b/static/themes/default/theme.css
@@ -255,13 +255,17 @@
     opacity: 1;
 }
 
+/* Remove the border from the un-pin icon */
+.kiwi-header-option-unpinsidebar {
+    border-left: none;
+}
+
 /* Leave channel */
-.kiwi-header-option-leave a:hover {
+.kiwi-header-option-leave a:hover,
+.kiwi-header-option-unpinsidebar a:hover {
     background-color: #d16c6c;
     color: #fff;
 }
-
-
 
 /* The link to click if the user has not joined this channel */
 .kiwi-header .kiwi-header-notjoined .u-link {

--- a/static/themes/default/theme.css
+++ b/static/themes/default/theme.css
@@ -11,38 +11,39 @@
     color: #201F1F;
 }
 
+
+
  /* Welcome Screen ( Welcome.vue ) */
  .kiwi-welcome-simple-form,
  .kiwi-customserver-form{
      background-color: #fff;
      border: 1px solid #ececec;
  }
-
  .kiwi-welcome-simple-error {
      border: 1px dashed #d86f6f;
  }
-
  .kiwi-welcome-simple-form .u-submit {
      background-color: #42b992;
      color: #fff;
  }
-
  .kiwi-welcome-simple .help {
      color: #666;
  }
-
  .kiwi-welcome-simple .help a {
      color: #666;
  }
-
  .kiwi-welcome-simple .help a:hover {
      color: #a9d87a;
  }
+
+
+
 
 /* Custom server layout */
 .kiwi-customserver {
 	background-color: #fbfbfb;
 }
+
 
 
 /* App ( App.vue ) */
@@ -52,25 +53,22 @@
 .kiwi-workspace::before {
     background: #42b992;
 }
-
 .kiwi-workspace::after{
     background-color: rgba(0, 0, 0, 0.4);
 }
 
+/* App - Tabs */
 .u-tabbed-content {
     background-color: #fff;
 }
-
 .u-tabbed-view-tabs {
     background: rgba(0, 0, 0, 0.1);
     border-bottom: 3px solid rgba(0, 0, 0, 0.1);
 }
-
 .u-tabbed-view-tabs .u-tabbed-view-tab {
     border-bottom: 3px solid rgba(0, 0, 0, 0.1);
     background: #fff;
 }
-
 .u-tabbed-view-tabs .u-tabbed-view-tab:hover,
 .u-tabbed-view-tabs .u-tabbed-view-tab.u-tabbed-view-tab--active{
     border-bottom: 3px solid #42b992;
@@ -80,23 +78,18 @@
 .input-text {
     background: #fff;
 }
-
 .input-text-label {
     color: gray;
 }
-
 .input-text--focus {
     border-color: #42b992;
 }
-
 .input-text-underline {
     border-color: #a9a9a9;
 }
-
 .input-text-underline-active {
     background: #42b992;
 }
-
 .u-form .u-input,
 .u-form textarea {
     border: 1px solid #ccc;
@@ -105,20 +98,6 @@
     line-height: normal;
     outline-color: #42b992;
 }
-
-.u-form input[type='checkbox'] {
-    border: 2px solid #000;
-    background-color: #fff;
-}
-
-.u-form input[type='checkbox']:after {
-    background: #42b992;
-}
-
-.u-form input[type='checkbox']:after {
-    background: #42b992;
-}
-
 .u-form label input[type='text'],
 .u-form label input[type='password'],
 .u-form label input[type='email'],
@@ -128,16 +107,23 @@
     border: 1px solid #42b992;
 }
 
+/* Checkbox Styling */
+.u-form input[type='checkbox'] {
+    border: 2px solid #000;
+    background-color: #fff;
+}
+.u-form input[type='checkbox']:after {
+    background: #42b992;
+}
+.u-form input[type='checkbox']:after {
+    background: #42b992;
+}
+
 /*buttons */
 .u-button {
     color: #2c3e50;
     text-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
 }
-
-.u-link {
-    color: #42b992;
-}
-
 .u-button-primary {
     background-color: #42b992;
     border: none;
@@ -155,74 +141,49 @@
     border-bottom: 1px solid #5f1515;
     color: #fff;
 }
-
+.u-link {
+    color: #42b992;
+}
 
 /* Application settings ( AppSettings.vue ) */
 .kiwi-appsettings {
     background: #fff;
 }
-
 .kiwi-appsettings-block {
     border: 1px solid rgba(0, 0, 0, 0.2);
 }
-
 .kiwi-appsettings-block h3 {
     background: #42b992;
     color: #fff;
 }
 
+/* Title bar, at the top of the Application settings component */
 .kiwi-appsettings-title {
     background-color: #42b992;
     color: #fff;
 }
-
 .kiwi-appsettings-title:hover{
     background: #d16c6c;
 }
 
-/* AutoComplete - Shows when typging with a command (AutoComplete.vue) */
-.kiwi-autocomplete {
-    box-shadow: 0 1px 15px rgba(64, 54, 63, 0.25);
-    border: 1px solid #ccc;
-    background: #fff;
-}
-
-.kiwi-autocomplete-item {
-    border-bottom: 1px solid #ccc;
-}
-
-.kiwi-autocomplete-item--selected {
-    background: #42b992;
-    color: #fff;
-}
-
-.kiwi-autocomplete-item--selected .u-link {
-    color: #fff;
-}
-
-/* Channel Banlist ( Channelbanlist.vue ) */
-.kiwi-channelbanlist-table tr {
-    border-bottom: 1px solid #ddd;
-}
 
 /* Channel List ( ChannelList.vue ) */
 .kiwi-channellist table tbody tr:nth-child(even) {
     background-color: #f9f9f9;
 }
-
 .kiwi-channellist table tbody tr {
     border-top: 1px solid lightgray;
 }
-
 .kiwi-channellist-users {
     background: #42b992;
 }
 
-/* Container - Main ( Container.vue ) */
+/* Container - Main ( Container.vue )  The majority of styling related to the messages and user input etc */
 .kiwi-container {
     border-bottom: 1px solid #ddd;
 }
 
+/* The join button is displayed in the header when the user has not connected to their currently selected network */
 .kiwi-header-join-channel-button {
     background-color: #42b983;
     color: #fff;
@@ -232,24 +193,21 @@
 .kiwi-container-toggledraw-sidebar {
     background: #fff;
 }
-
 .kiwi-container-toggledraw-statebrowser {
     border-right: 1px solid #ddd;
 }
-
 .kiwi-container-toggledraw-sidebar {
     border-left: 1px solid #ddd;
 }
-
 .kiwi-container-toggledraw-sidebar--disabled {
     color: #b8babd;
 }
 
+/* These styles relate to the 'unread messages' and 'Mentioned' highlights that display to the user in the Statebrowser sidebar */
 .kiwi-container-toggledraw-statebrowser-messagecount {
     background-color: #42b983;
     color: #fff;
 }
-
 .kiwi-container-toggledraw-statebrowser-messagecount::after {
     border: 0.6em solid transparent;
     border-right-color: #ddd;
@@ -258,7 +216,6 @@
 .kiwi-statebrowser-channel-label--highlight {
     background: #e45e5e;
 }
-
 .kiwi-container-toggledraw-statebrowser-messagecount--highlight::after {
     border-right-color: #d62323;
 }
@@ -272,83 +229,34 @@
 .kiwi-header {
     background: #fff;
 }
-
-.kiwi-messagelist-message--compact.kiwi-messagelist-message-topic,
-.kiwi-messagelist-message--modern.kiwi-messagelist-message-topic {
-    border-top: 1px solid #42b992;
-    border-bottom: 1px solid #42b992;
-    color: #5f5f5f;
-    background: #f5f5f5;
-}
-
-.kiwi-messagelist-message--modern.kiwi-messagelist-message-topic.kiwi-messagelist-message--unread {
-    border-left: 2px solid #42b992;
-}
-
-.kiwi-messagelist-message--modern.kiwi-messagelist-message--authorrepeat.kiwi-messagelist-message-topic {
-    border-top: 2px solid #42b992;
-}
-
-.kiwi-messagelist-message--modern.kiwi-messagelist-message-topic {
-  border: 2px solid #42b992;
-}
-
-.kiwi-header-buffersettings {
-    border-top: 1px solid #ddd;
-}
-
-.kiwi-header-topic > div {
-    color: #22231f;
-}
-
 .kiwi-header-name {
     color: #22231f;
 }
 
-.kiwi-header-buffersettings {
-    border-top: 1px solid #ddd;
-}
-
+/* The header option buttons */
 .kiwi-header-option {
     border-left: 1px solid rgba(0, 0, 0, 0.2);
 }
-
 .kiwi-header-option a:hover,
 .kiwi-header-option--active a {
     background-color: #42b992;
     color: #fff;
     opacity: 1;
 }
-
 .kiwi-header-option--active {
     border-left: 1px solid #42b992;
 }
-
-.kiwi-statebrowser-network .kiwi-statebrowser-network-header a.kiwi-statebrowser-network-toggle:hover {
-    background-color: #d16c6c;
-    border-top-color: #d16c6c;
-}
-
 .kiwi-header-option-topic.kiwi-header-option--active,
 .kiwi-header-option-leave a:hover {
     background-color: #d16c6c;
     color: #fff;
 }
 
-.kiwi-statebrowser-channel-settings,
-.kiwi-statebrowser-channel-leave {
-    background-color: #22231f;
-}
-
-.kiwi-statebrowser-channel-settings:hover{
-    background-color: #42b992;
-}
-
+/* The link to click if the user has not joined this channel */
 .kiwi-header .kiwi-header-notjoined .u-link {
     background-color: #42b992;
     color: #fff;
 }
-
 .kiwi-header .kiwi-header-notjoined .u-link:hover {
     background-color: #5ec9a6;
 }
@@ -358,13 +266,8 @@
     background-color: #42b992;
     color: #fff;
 }
-
 .kiwi-header .kiwi-header-notjoined .u-link:hover {
     background-color: #5ec9a6;
-}
-
-.kiwi-header-name {
-    color: #22231f;
 }
 
 .kiwi-header-server-connection .u-button {
@@ -372,52 +275,126 @@
     color: #fff;
 }
 
+
+/* baseline styling for the 'topic' of the channel, if it has one, these are shared between traditional and modern view, but can be made more specific if need be */
+.kiwi-messagelist-message.kiwi-messagelist-message-topic {
+    border-top: 1px solid #42b992;
+    border-bottom: 1px solid #42b992;
+    color: #5f5f5f;
+    background: #f5f5f5;
+}
+.kiwi-messagelist-message--modern.kiwi-messagelist-message--authorrepeat.kiwi-messagelist-message-topic {
+    border-top: 2px solid #42b992;
+}
+.kiwi-messagelist-message--modern.kiwi-messagelist-message-topic {
+    border: 2px solid #42b992;
+}
+.kiwi-messagelist-message--modern.kiwi-messagelist-message-topic.kiwi-messagelist-message--unread {
+    border-left: 2px solid #42b992;
+}
+.kiwi-header-buffersettings {
+    border-top: 1px solid #ddd;
+}
+.kiwi-header-topic > div {
+    color: #22231f;
+}
+
+
+
+/* When hovering over a channel, these options are displayed and coloured upon hover */
+.kiwi-statebrowser-channel-settings,
+.kiwi-statebrowser-channel-leave {
+    background-color: #22231f;
+}
+.kiwi-statebrowser-channel-settings:hover{
+    background-color: #42b992;
+}
+.kiwi-statebrowser-channel-leave:hover{
+    background: #d16c6c;
+}
+
+
+
 /* Control Input - displayed at bottom of Kiwi ( ControlInput.vue ) */
 .kiwi-controlinput {
     background: #fff;
     border-top: 1px solid rgba(0, 0, 0, 0.2);
 }
-
 .kiwi-controlinput .kiwi-controlinput-user,
 .kiwi-controlinput-inner .kiwi-controlinput-user {
     border-right: 1px solid rgba(0, 0, 0, 0.2);
 }
-
 .kiwi-controlinput-active-tool {
     background: #f6f6f6;
 }
+/* AutoComplete - If the user has enabled autocomplete in their options, this will style the options (AutoComplete.vue) */
+.kiwi-autocomplete {
+    box-shadow: 0 1px 15px rgba(64, 54, 63, 0.25);
+    border: 1px solid #ccc;
+    background: #fff;
+}
+.kiwi-autocomplete-item {
+    border-bottom: 1px solid #ccc;
+}
+.kiwi-autocomplete-item--selected {
+    background: #42b992;
+    color: #fff;
+}
+.kiwi-autocomplete-item--selected .u-link {
+    color: #fff;
+}
+
+
 
 /* Message list - Standard messages ( MessageList.vue ) */
 .kiwi-messagelist {
     background: #fff;
 }
-
 .kiwi-messagelist-message--info-open {
     background: #f6f6f6;
 }
-
 .kiwi-messageinfo-urls {
     border-top: 1px solid #ddd;
 }
-
 .kiwi-messagelist-message-action .kiwi-messagelist-body {
     color: #090;
     font-style: italic;
 }
-
 .kiwi-messagelist-message--highlight {
     background-color: #f2f2f2;
 }
 
-/*When hovering over a users messages */
+/* Standard username and usertime styling */
+.kiwi-messagelist-nick {
+    color: #000;
+}
+.kiwi-messagelist-time {
+    color: #a0a09f;
+}
+
+/* Unread user messages */
+.kiwi-messagelist-message.kiwi-messagelist-message--unread,
+.kiwi-messagelist-message.kiwi-messagelist-message--unread {
+  border-left: 5px solid #42b992;
+  background: #f2f2f2;
+  opacity: 1;
+}
+.kiwi-messagelist-message.kiwi-messagelist-message.kiwi-messagelist-message--unread.kiwi-messagelist-message-connection {
+    border-left: none;
+    background: #42b983;
+}
+
+/* When hovering over a users messages */
 .kiwi-messagelist-message--hover{
     background-color: #f2f2f2;
 }
 
+/* The shadow over the main text area that displays when the sidebar is open */
 .kiwi-container--sidebar-open .kiwi-messagelist::after {
     background-color: #000;
 }
 
+/* Connection Styling */
 .kiwi-messagelist-message-connection {
     background-color: #fff;
 }
@@ -426,39 +403,12 @@
     background-color: #42b992;
     color: #fff;
 }
-
 .kiwi-messagelist-message.kiwi-messagelist-message-connection-disconnected .kiwi-messagelist-body {
     background-color: #f16f74;
     color: #fff;
 }
 
-.kiwi-messagelist-message.kiwi-messagelist-message--unread,
-.kiwi-messagelist-message.kiwi-messagelist-message--unread {
-  border-left: 5px solid #42b992;
-  background: #f2f2f2;
-  opacity: 1;
-}
-
-.kiwi-messagelist-message.kiwi-messagelist-message.kiwi-messagelist-message--unread.kiwi-messagelist-message--unread.kiwi-messagelist-message-connection {
-    border-left: none;
-    background: #42b983;
-}
-
-.kiwi-messagelist-message--compact .kiwi-messagelist-message-privmsg:hover,
-.kiwi-messagelist-message--compact .kiwi-messagelist-message-action:hover,
-.kiwi-messagelist-message--compact .kiwi-messagelist-message-notice:hover, {
-    border-left-color: #80ab52;
-}
-
-/* Style the banlist */
-.kiwi-channelbanlist-table-actions:hover {
-    background-color: #b9424a;
-}
-
-.kiwi-channelbanlist-table-actions:hover i {
-    color: #fff;
-}
-
+/* Traffic Messages - User join , User Quit etc*/
 .kiwi-messagelist-message-traffic-join {
     color: #090;
 }
@@ -474,11 +424,6 @@
     color: #900;
 }
 
-.kiwi-messagelist-seperator::after {
-    border-color: #ddd;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.4);
-}
-
 /* Errors */
 .kiwi-messagelist-message-error {
     background: #f1d4d4;
@@ -489,31 +434,25 @@
 .kiwi-messagelist-modern-avatar {
     border: 2px solid #42b992;
 }
-
 .kiwi-messagelist-message--modern .kiwi-messagelist-body a {
   color: #0093ce;
 }
-
 .kiwi-messagelist-message--modern .kiwi-messagelist-body a:hover {
   color: #3db0de;
 }
-
-.kiwi-messagelist-nick {
-    color: #000;
-}
-
-.kiwi-messagelist-time {
-    color: #a0a09f;
-}
-
 .kiwi-messagelist-message--modern {
   border-top: 1px solid #f3f3f3;
 }
-
 .kiwi-messagelist-message--modern.kiwi-messagelist-message--authorrepeat {
   border-top: none;
 }
 
+/* Traditional message styling hover */
+.kiwi-messagelist-message--compact .kiwi-messagelist-message-privmsg:hover,
+.kiwi-messagelist-message--compact .kiwi-messagelist-message-action:hover,
+.kiwi-messagelist-message--compact .kiwi-messagelist-message-notice:hover, {
+    border-left-color: #80ab52;
+}
 
 /* Network Settings ( NetworkSettings.vue ) */
 .kiwi-networksettings .kiwi-title {
@@ -521,72 +460,56 @@
     color: #fff;
     border-top: 1px solid #42b992;
 }
-
 .kiwi-network-nicknamelabel {
     color: rgb(128, 128, 128);
 }
-
 .kiwi-networksettings .kiwi-padded-form-element-container.kiwi-dangerzone {
     border-top: 1px solid rgba(0, 0, 0, 0.2);
 }
-
 .kiwi-networksettings .u-form {
     border: 1px solid rgba(0, 0, 0, 0.2);
 }
-
 .kiwi-networksettings .kiwi-title span {
     color: #42b992;
     background: #fff;
 }
-
 .kiwi-networksettings-advanced h3:hover {
     color: #42b992;
 }
-
 .kiwi-networksettings .kiwi-customserver-tls {
     color: #bfbfbf;
 }
-
 .kiwi-networksettings .u-form{
     background: #fff;
 }
-
 .kiwi-networksettings .kiwi-customserver-tls {
     color: #bfbfbf;
 }
-
+.kiwi-networksettings  .kiwi-customserver-tls--enabled {
+    color: green;
+}
+.kiwi-networksettings  .kiwi-customserver-tls--enabled .kiwi-customserver-tls-lock {
+    color: green;
+}
+.kiwi-networksettings  .kiwi-customserver-tls-minus {
+    color: red;
+}
 .kiwi-networksettings-error {
     border: 1px dashed #d86f6f;
 }
-
 .kiwi-networksettings .kiwi-connect-to-newnetwork {
     background: #42b992;
     color: #fff;
 }
-
-.kiwi-networksettings  .kiwi-customserver-tls--enabled {
-    color: green;
-}
-
-.kiwi-networksettings  .kiwi-customserver-tls--enabled .kiwi-customserver-tls-lock {
-    color: green;
-}
-
-.kiwi-networksettings  .kiwi-customserver-tls-minus {
-    color: red;
-}
-
 .kiwi-networksettings .kiwi-networksettings-server-types .kiwi-network-type-button {
     border: 1px solid #42b992;
     color: #42b992;
 }
-
 .kiwi-networksettings .kiwi-networksettings-server-types .kiwi-network-type-button:hover,
 .kiwi-networksettings .kiwi-networksettings-server-types .kiwi-network-type-button.kiwi-networksettings-server-type-active {
     background: #42b992;
     color: #fff;
 }
-
 .u-button.kiwi-channellist-refresh.u-button-secondary {
   background: #42b992;
 }
@@ -595,51 +518,36 @@
 .kiwi-nicklist-usercount {
     border-bottom: 1px solid rgba(0, 0, 0, 0.2);
 }
-
 .kiwi-nicklist-info{
     border-top: 1px solid rgba(0, 0, 0, 0.2);
 }
-
 .kiwi-nicklist-info input {
     background-color: #fff;
     color: #000;
 }
-
 .kiwi-nicklist-user {
     border-top: 1px solid #858585;
 }
-
 .kiwi-nicklist-user:first-of-type {
     border-top: none;
 }
-
-.kiwi-nicklist-user:after {
-    color: #666764;
-}
-
-.kiwi-nicklist-user:hover {
-    background-color: #42b992;
-    color: #fff;
-}
-
 .kiwi-nicklist-user:hover {
     background-color: #42b992;
     cursor: pointer;
     color: #fff;
 }
-
+.kiwi-nicklist-user:after {
+    color: #666764;
+}
 .kiwi-nicklist-user:hover .kiwi-nicklist-user-nick {
     color: #fff !important;
 }
-
 .kiwi-nicklist-user:hover .kiwi-nicklist-user-nick:after {
     color: #fff;
 }
-
 .kiwi-nicklist-messageuser {
     color: #666764;
 }
-
 .kiwi-nicklist-info i.fa-search {
     color: #cfcfcf;
 }
@@ -649,12 +557,10 @@
     color: #fff;
     background-color: #bf5155;
 }
-
 .kiwi-notconnected-button {
     border: 2px solid #fff;
     color: #fff;
 }
-
 .kiwi-notconnected-button:hover{
     background-color: #fff;
     color: #000;
@@ -664,11 +570,9 @@
 .kiwi-controlinput-selfuser {
     background: #fff;
 }
-
 .kiwi-controlinput-selfuser.kiwi-controlinput-selfuser--open {
     border: 1px solid #ddd;
 }
-
 .kiwi-selfuser-actions {
     border-top: 1px solid #ddd;
 }
@@ -677,16 +581,13 @@
 .kiwi-settings-aliases-input {
     border-color: #ccc;
 }
-
 .kiwi-settings-aliases-showhelp {
     display: block;
 }
-
 .kiwi-settings-aliases-help {
     background: transparent;
     border: 1px dashed rgba(0,0,0, 0.4);
 }
-
 .kiwi-settings-aliases-help em {
     color: #42b992;
     font-weight: 900;
@@ -697,22 +598,29 @@
     background-color: #42b992;
     color: #fff;
 }
-
 .kiwi-sidebar-options:hover {
     background: #d16c6c;
 }
-
 .kiwi-container--sidebar-pinned .kiwi-sidebar {
     border-color: #b2b2b2;
 }
 
+/* Channel Banlist ( Channelbanlist.vue ) */
+.kiwi-channelbanlist-table tr {
+    border-bottom: 1px solid #ddd;
+}
+.kiwi-channelbanlist-table-actions:hover {
+    background-color: #b9424a;
+}
+.kiwi-channelbanlist-table-actions:hover i {
+    color: #fff;
+}
 
 /* Statebrowser - Left sidebar ( StateBrowser.vue ) */
 .kiwi-statebrowser {
     background: #22231f;
     color: #fff;
 }
-
 .kiwi-statebrowser-divider {
     background: rgba(255, 255, 255, 0.3);
 }
@@ -728,31 +636,28 @@
     background-color: #000;
     color: #fff;
 }
-
 .kiwi-statebrowser-usermenu-avatar:hover {
     background-color: #42b992;
     color: #fff;
-}
-
-.kiwi-statebrowser-scrollarea {
-    border-bottom: 1px solid rgba(255, 255, 255, 0.3);
 }
 
 /* If the user clicks on their avatar we 'open' the settings */
 .kiwi-statebrowser-usermenu--open {
     background: rgba(255, 255, 255, 0.1);
 }
-
 .kiwi-statebrowser-usermenu--open .kiwi-statebrowser-usermenu-avatars {
     background-color: #42b992;
     color: #fff;
+}
+.kiwi-statebrowser-network .kiwi-statebrowser-network-header a.kiwi-statebrowser-network-toggle:hover {
+    background-color: #d16c6c;
+    border-top-color: #d16c6c;
 }
 
 /* User Settings */
 .kiwi-statebrowser-appsettings {
     border: 1px solid rgba(255, 255, 255, 0.5);
 }
-
 .kiwi-statebrowser-appsettings:hover {
     background: #42b992;
     color: #fff;
@@ -760,26 +665,23 @@
 }
 
 /* Statebrowser list */
+.kiwi-statebrowser-scrollarea {
+    border-bottom: 1px solid rgba(255, 255, 255, 0.3);
+    background-color: #131312;
+}
 .kiwi-statebrowser-scrollarea h4,
 .kiwi-statebrowser-scrollarea h4 {
     border-top: 1px solid rgba(255, 255, 255, 0.3);
 }
-
 .kiwi-network-name-options {
     background-color: #131312;
 }
-
 .kiwi-network-name-options .option-button:hover,
 .kiwi-network-name-options .option-button.active {
     background-color: #42b992;
     color: #fff;
 }
-
 .kiwi-network-name-options .kiwi--collapse {
-    background: #d16c6c;
-}
-
-.kiwi-statebrowser-channel-leave:hover{
     background: #d16c6c;
 }
 
@@ -787,20 +689,13 @@
 .kiwi-statebrowser-newchannel-inputwrap {
     color: #fff;
 }
-
 .kiwi-statebrowser-newchannel-inputwrap input[type='text'] {
     color: #000;
     background: #fff;
 }
-
 .kiwi-statebrowser-newchannel-inputwrap--focus {
     opacity: 1;
     background-color: #fff;
-}
-
-/* Set the height of the networks scroll box */
-.kiwi-statebrowser-scrollarea {
-    background-color: #131312;
 }
 
 /*Channel search input */
@@ -809,17 +704,14 @@
     border-bottom: 1px solid rgba(255, 255, 255, 0.5);
     color: #131312;
 }
-
 .kiwi-statebrowser-channelfilter::after {
     color: #000;
 }
-
 .kiwi-statebrowser-channelfilter input {
     background-color: #fff;
     color: #000;
     outline: none;
 }
-
 .kiwi-statebrowser-channelfilter p {
     color: #42b992;
     font-size: 0.9em;
@@ -827,27 +719,22 @@
     cursor: pointer;
     transition: all 0.3s;
 }
-
 .kiwi-statebrowser-channelfilter p:hover {
     color: #6dcdad;
 }
-
 .kiwi-statebrowser-newnetwork a {
     color: #fff;
     border: 1px solid rgba(255, 255, 255, 0.5);
 }
-
 .kiwi-statebrowser-newnetwork a:hover {
     background: #42b992;
     border-color: #42b992;
     opacity: 1;
     color: #fff;
 }
-
 .kiwi-statebrowser-network .kiwi-statebrowser-network-header {
     background-color: #454545;
 }
-
 .kiwi-statebrowser-network .kiwi-statebrowser-network-header a {
     color: #fff;
 }
@@ -862,29 +749,23 @@
     border-bottom: 1px solid #4a4b47;
     color: #fff;
 }
-
 .kiwi-statebrowser-channels  .kiwi-statebrowser-channel .kiwi-statebrowser-channel-name {
     color: #fff;
 }
-
 .kiwi-statebrowser-channels  .kiwi-statebrowser-channel .kiwi-statebrowser-channel-name  .kiwi-statebrowser-channel-label {
     background: #d16c6c;
 }
-
 .kiwi-statebrowser-channel.kiwi-statebrowser-channel-active {
     border-left: 3px solid #42b992;
 }
-
 .kiwi-search-channels.active{
     background: #42b992;
 }
-
 
 /* New Channel Button */
 .kiwi-statebrowser-newchannel a {
     border: 1px solid rgba(255, 255, 255, 0.5);
 }
-
 .kiwi-statebrowser-newchannel a:hover {
     background: #42b992;
     opacity: 1;
@@ -895,7 +776,6 @@
     background-color: #fc6262;
     color: #fff;
 }
-
 .kiwi-statebrowser-usermenu-body .close-icon:hover {
     background-color: #fe7575;
 }
@@ -903,109 +783,71 @@
 .kiwi-statebrowser-switcher a:first-of-type {
     background: rgba(255, 255, 255, 0.15);
 }
-
 .kiwi-statebrowser-switcher a:hover {
     background: rgba(255, 255, 255, 0.1);
 }
 
-
 .kiwi-statebrowser-options {
     background: #383838;
 }
-
 .kiwi-statebrowser-nonetworks {
     background: rgba(255, 255, 255, 0.15);
 }
-
 .kiwi-statebrowser-availablenetworks-toggle {
     background: rgba(255, 255, 255, 0.15);
 }
-
 .kiwi-statebrowser-availablenetworks {
     border-bottom: 1px solid rgba(255, 255, 255, 0.3);
 }
-
 .kiwi-statebrowser-availablenetworks-link {
     border-right: 15px solid red;
 }
-
 .kiwi-statebrowser-availablenetworks-link--connected {
     border-color: #42b992;
 }
-
 .kiwi-statebrowser-channel-notjoined .kiwi-statebrowser-channel-name {
     color: #d03232;
 }
-
 .kiwi-statebrowser-channel-active .kiwi-statebrowser-channel-name {
     color: #df6b26;
 }
-
 .kiwi-statebrowser-channel-label {
     background: #42b992;
     color: #fff;
 }
-
 .kiwi-statebrowser-channel-label--highlight {
     background: #d62323;
 }
-
 .kiwi-statebrowser-channel-popup {
     background: #383838;
     border: 3px solid #6b6b6b;
     border-left: none;
 }
-
 .kiwi-statebrowser-newchannel-inputwrap--focus {
     opacity: 1;
 }
-
 .kiwi-statebrowser-usermenu-body .close-icon {
     background-color: #fc6262;
     color: #fff;
 }
-
 .kiwi-statebrowser-usermenu-body .close-icon:hover {
     background-color: #fe7575;
-}
-
-.kiwi-statebrowser-switcher a:first-of-type {
-    background: rgba(255, 255, 255, 0.15);
-}
-
-.kiwi-statebrowser-switcher a:hover {
-    background: rgba(255, 255, 255, 0.1);
-}
-
-.kiwi-statebrowser-options {
-    background: #383838;
 }
 
 .kiwi-statebrowser-nonetworks {
     background: rgba(255, 255, 255, 0.15);
 }
-
-.kiwi-statebrowser-availablenetworks-toggle {
-    background: rgba(255, 255, 255, 0.15);
-}
-
 .kiwi-statebrowser-availablenetworks {
     border-bottom: 1px solid rgba(255, 255, 255, 0.3);
 }
-
-.kiwi-statebrowser-channel-notjoined .kiwi-statebrowser-channel-name {
-    color: #d03232;
-}
-
-.kiwi-statebrowser-channel-active .kiwi-statebrowser-channel-name {
-    color: #df6b26;
+.kiwi-statebrowser-availablenetworks-toggle {
+    background: rgba(255, 255, 255, 0.15);
 }
 
 .kiwi-statebrowser-channel-label {
     background: #42b992;
     color: #dedede;
 }
-
 .kiwi-statebrowser-channel-label--highlight {
     background: #d62323;
 }
@@ -1019,47 +861,37 @@
 .kiwi-statebrowser-network-header {
     background: rgba(255, 255, 255, 0.15);
 }
-
 .kiwi-statebrowser-network-status {
     background: rgba(255, 255, 255, 0.1);
 }
-
 .kiwi-statebrowser-channel-active {
     background: rgba(255, 255, 255, 0.05);
 }
-
 
 /* User Box Styling ( UserBox.vue ) */
 .kiwi-userbox-usermask {
     color: #9e9e9e;
 }
-
 .kiwi-userbox-opactions {
     border-top: 1px solid #9e9e9e;
 }
-
 .kiwi-userbox .main-title {
     border-bottom: 1px solid rgba(0, 0, 0, 0.2);
 }
-
 .kiwi-userbox .kiwi-userbox-basicinfo {
     border-bottom: 1px solid rgba(0, 0, 0, 0.2);
 }
-
 .kiwi-userbox .kiwi-userbox-actions .u-button {
     border: 1px solid #000;
     color: #000;
 }
-
 .kiwi-userbox .kiwi-userbox-actions .u-button:hover {
     background-color: #000;
     color: #fff;
 }
-
 .kiwi-userbox-opactions {
     border-top: 1px solid #9e9e9e;
 }
-
 .kiwi-userbox-opactions label select {
     border: 1px solid rgba(0, 0, 0, 0.2);
 }
@@ -1069,11 +901,9 @@
 .kiwi-userbox-opaction-kickban {
     color: #fff;
 }
-
 .kiwi-userbox-opaction-kick {
     background-color: #f6c358;
 }
-
 .kiwi-userbox-opaction-kick:hover {
     background-color: #fcce6e;
 }
@@ -1081,7 +911,6 @@
 .kiwi-userbox-opaction-ban {
     background-color: #fcb46e;
 }
-
 .kiwi-userbox-opaction-ban:hover{
     background-color: #ffca97;
 }
@@ -1089,7 +918,6 @@
 .kiwi-userbox-opaction-kickban{
     background-color: #fb846a;
 }
-
 .kiwi-userbox-opaction-kickban:hover{
     background-color: #ffaf9e;
 }
@@ -1098,7 +926,6 @@
     border: 1px solid #9e9e9e;
     border-radius: 2px;
 }
-
 .kiwi-messagelist-message-whois {
     border-left-color: #939393;
 }

--- a/static/themes/default/theme.css
+++ b/static/themes/default/theme.css
@@ -238,7 +238,8 @@
     border-left: 1px solid rgba(0, 0, 0, 0.2);
 }
 .kiwi-header-option a:hover,
-.kiwi-header-option--active a {
+.kiwi-header-option--active a,
+.kiwi-header-option.kiwi-header-option-active {
     background-color: #42b992;
     color: #fff;
     opacity: 1;
@@ -539,7 +540,7 @@
 .kiwi-nicklist-user:after {
     color: #666764;
 }
-.kiwi-nicklist-user:hover .kiwi-nicklist-user-nick {
+.kiwi-nicklist-user:hover .kiwi-nicklist-user-nick i {
     color: #fff !important;
 }
 .kiwi-nicklist-user:hover .kiwi-nicklist-user-nick:after {


### PR DESCRIPTION
This update deals with some small styling changes,
-  Cleaning up the default theme to make it far easier to change for users 
-  The pin has now been styled for pin/unpin 
-  Buttons in the container header now get an active class, with the pin on or off
-  The small white pixels in the bottom left and bottom right corners are gone (atlast!)
-  Buttons in the container Header, when hovered, will display their child element with an opacity of 1, to make them easier to read.
- Some small styling tweaks/fixes