### PR TITLE
api fix style for addUi header_channel & header_query

### DIFF
--- a/src/components/ContainerHeader.vue
+++ b/src/components/ContainerHeader.vue
@@ -10,6 +10,7 @@
         <template v-if="isChannel()">
             <div class="kiwi-header-name">{{buffer.name}}</div>
             <div class="kiwi-header-options" v-if="isJoined && isConnected">
+                <div v-for="el in pluginUiChannelElements" v-rawElement="el" class="kiwi-header-option"></div>
                 <div class="kiwi-header-option kiwi-header-option-topic" @click="showTopic" v-bind:class="{ 'kiwi-header-option--active': viewTopic == true }" v-if="buffer.topic.length > 0">
                     <a v-if="viewTopic"><i class="fa fa-info" aria-hidden="true"></i> <span class="kiwi-containerheader-hidetext">Hide Topic</span></a>
                     <a v-if="!viewTopic"><i class="fa fa-info" aria-hidden="true"></i> <span class="kiwi-containerheader-hidetext">Display Topic</span></a>
@@ -21,9 +22,6 @@
             </div>
             <div v-if="!isJoined && isConnected" class="kiwi-header-notjoined">
                 <a @click="joinCurrentBuffer" class="u-link kiwi-header-join-channel-button">{{$t('container_join')}}</a>
-            </div>
-            <div class="kiwi-header-tools">
-                <div v-for="el in pluginUiChannelElements" v-rawElement="el" class="kiwi-header-tool"></div>
             </div>
 
             <div v-if="isJoined && buffer.topic.length > 0 && viewTopic" class="kiwi-header-topic">
@@ -46,11 +44,13 @@
 
         <template v-else-if="isQuery()">
             <div class="kiwi-header-name">{{buffer.name}}</div>
-            <div class="kiwi-header-tools">
-                <div v-for="el in pluginUiQueryElements" v-rawElement="el" class="kiwi-header-tool"></div>
-            </div>
             <div class="kiwi-header-options">
-                <div class="kiwi-header-option kiwi-header-option-leave"><a @click="closeCurrentBuffer"><i class="fa fa-times" aria-hidden="true"></i></a></div>
+                <div v-for="el in pluginUiQueryElements" v-rawElement="el" class="kiwi-header-option"></div>
+                <div class="kiwi-header-option kiwi-header-option-leave">
+                    <a @click="closeCurrentBuffer">
+                        <i class="fa fa-times" aria-hidden="true"></i>
+                    </a>
+                </div>
             </div>
         </template>
 


### PR DESCRIPTION
Although this seems to fix some of the other component leaking issues it still does not work correctly

the below plugin should put different buttons in channel vs query but the channel button leaks into query and the query button is mia

https://gist.github.com/ItsOnlyBinary/65431700c97d4233fef768ddf633bf26

if you duplicate "kiwi.addUi('header_query', queryDiv);" then the query has both a channel and a query button.....