### PR TITLE
Fix - Mobile, userbox overflowing when on small screens

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -335,7 +335,7 @@ export default {
 
     .kiwi-container--sidebar-open .kiwi-sidebar {
         width: 100%;
-        max-width: none;
+        max-width: 100%;
     }
 
     .kiwi-sidebar-buffersettings {


### PR DESCRIPTION
- Simple fix to ensure sidebars don't overflow the app, when they have a fixed width