### PR TITLE
 Add in new MessageList Component, to display messages as text

### DIFF
--- a/src/components/AppSettings.vue
+++ b/src/components/AppSettings.vue
@@ -39,8 +39,17 @@
                     <div class="kiwi-appsettings-block">
                         <h3>{{$t('settings_messages_title')}}</h3>
                         <div class="kiwi-appsettings-section kiwi-appsettings-messages">
+                            <label for="kiwi-select-layout">
+                                <span>{{$t('settings_select_layout')}}</span>
+                                <select class="" id="kiwi-select-layout" @change="settingMessageLayout()" v-model="settingSelectedLayout">
+                                    <option value="" disabled selected="selected">Please Select Layout</option>
+                                    <option value="modern">Modern Layout (Default)</option>
+                                    <option value="traditional">Traditional Layout</option>
+                                    <option value="text">Text Layout</option>
+                                </select>
+                            </label>
                             <label>
-                                <span>{{$t('settings_layout_compact')}} </span>
+                                <span>{{$t('settings_layout_compact')}}</span>
                                 <input type="checkbox" v-model="settingMessageLayout" />
                             </label>
                             <label><span>{{$t('settings_timestamps')}} </span> <input type="checkbox" v-model="settingBufferShowTimestamps" /></label>
@@ -153,18 +162,7 @@ export default {
         settingBufferMuteSound: bindSetting('buffers.mute_sound'),
         settingDefaultBanMask: bindSetting('buffers.default_ban_mask'),
         settingDefaultKickReason: bindSetting('buffers.default_kick_reason'),
-        settingMessageLayout: {
-            get: function getSettingMessageLayout() {
-                return state.setting('messageLayout') === 'compact';
-            },
-            set: function setSettingMessageLayout(newVal) {
-                if (newVal) {
-                    state.setting('messageLayout', 'compact');
-                } else {
-                    state.setting('messageLayout', 'modern');
-                }
-            },
-        },
+        settingSelectedLayout: bindSetting('messageLayout'),
     },
     components: {
         SettingsAliases,
@@ -220,6 +218,18 @@ export default {
                 this.$watch('theme', watchTheme),
                 this.$watch('customThemeUrl', watchCustomThemeUrl),
             ];
+        },
+        settingMessageLayout: function settingMessageLayout(settingSelectedLayout) {
+            console.log('hi');
+            if (settingSelectedLayout === 'compact') {
+                state.setting('messageLayout', 'compact');
+            }
+            if (settingSelectedLayout === 'modern') {
+                state.setting('messageLayout', 'modern');
+            }
+            if (settingSelectedLayout === 'text') {
+                state.setting('messageLayout', 'text');
+            }
         },
     },
     created: function created() {

--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -17,17 +17,23 @@
 
             <component v-if="message.render() && message.template" v-bind:is="message.template" :message="message" :buffer="buffer"></component>
             <message-list-message-modern
-                v-else-if="listType === 'modern'"
+                v-if="listType === 'modern'"
                 :message="message"
                 :idx="idx"
                 :ml="thisMl"
             ></message-list-message-modern>
             <message-list-message-compact
-                v-else-if="listType !== 'modern'"
+                v-if="listType === 'compact'"
                 :message="message"
                 :idx="idx"
                 :ml="thisMl"
             ></message-list-message-compact>
+            <message-list-message-text
+                v-if="listType === 'text'"
+                :message="message"
+                :idx="idx"
+                :ml="thisMl"
+            ></message-list-message-text>
         </div>
 
         <not-connected
@@ -46,6 +52,7 @@ import * as TextFormatting from '@/helpers/TextFormatting';
 import NotConnected from './NotConnected';
 import MessageListMessageCompact from './MessageListMessageCompact';
 import MessageListMessageModern from './MessageListMessageModern';
+import MessageListMessageText from './MessageListMessageText';
 
 // If we're scrolled up more than this many pixels, don't auto scroll down to the bottom
 // of the message list
@@ -56,6 +63,7 @@ export default {
         NotConnected,
         MessageListMessageModern,
         MessageListMessageCompact,
+        MessageListMessageText,
     },
     data: function data() {
         return {

--- a/src/components/MessageListMessageText.vue
+++ b/src/components/MessageListMessageText.vue
@@ -1,0 +1,188 @@
+<template>
+    <div
+        @click="ml.onMessageClick($event, message)"
+        class="kiwi-messagelist-message kiwi-messagelist-message--text"
+        v-bind:class="[
+            ml.filteredMessages[idx-1] &&
+            ml.filteredMessages[idx-1].nick === message.nick &&
+            message.time - ml.filteredMessages[idx-1].time < 60000 &&
+            ml.filteredMessages[idx-1].type !== 'traffic' &&
+            message.type !== 'traffic' ?
+                'kiwi-messagelist-message--authorrepeat' :
+                '',
+            'kiwi-messagelist-message-' + message.type,
+            message.type_extra ?
+                'kiwi-messagelist-message-' + message.type + '-' + message.type_extra :
+                '',
+            ml.isMessageHighlight(message) ?
+                'kiwi-messagelist-message--highlight' :
+                '',
+            ml.isHoveringOverMessage(message) ?
+                'kiwi-messagelist-message--hover' :
+                '',
+            ml.buffer.last_read && message.time > ml.buffer.last_read ?
+                'kiwi-messagelist-message--unread' :
+                '',
+            message.nick.toLowerCase() === ml.ourNick.toLowerCase() ?
+                'kiwi-messagelist-message--own' :
+                '',
+            ml.message_info_open === message ?
+                'kiwi-messagelist-message--info-open' :
+                '',
+            ml.message_info_open && ml.message_info_open !== message ?
+                'kiwi-messagelist-message--blur' :
+                '',
+        ]"
+        :data-message="message"
+        :data-nick="(message.nick||'').toLowerCase()"
+    >
+    <div class="kiwi-messagelist-body">
+        <span
+            v-if="ml.bufferSetting('show_timestamps')"
+            class="kiwi-messagelist-time"
+        >
+            {{ml.formatTime(message.time)}}
+        </span>
+        <span
+            class="kiwi-messagelist-nick"
+            v-bind:style="ml.nickStyle(message.nick)"
+            v-bind:data-nick="message.nick"
+            @mouseover="ml.hover_nick=message.nick.toLowerCase();"
+            @mouseout="ml.hover_nick='';"
+        >
+            {{message.user ? userModePrefix(message.user) : ''}}{{message.nick}}
+        </span>
+        <span v-html="ml.formatMessage(message)"></span>
+    </div>
+
+        <message-info
+            v-if="ml.message_info_open===message"
+            :message="message"
+            :buffer="ml.buffer"
+            @close="ml.toggleMessageInfo()"
+        />
+    </div>
+</template>
+
+<script>
+
+// import state from '@/libs/state';
+import * as Misc from '@/helpers/Misc';
+import MessageInfo from './MessageInfo';
+
+export default {
+    components: {
+        MessageInfo,
+    },
+    data: function data() {
+        return {
+        };
+    },
+    props: ['ml', 'message', 'idx'],
+    computed: {
+    },
+    methods: {
+        isHoveringOverMessage: function isHoveringOverMessage(message) {
+            return message.nick && message.nick.toLowerCase() === this.hover_nick.toLowerCase();
+        },
+        userModePrefix: function userModePrefix(user) {
+            return Misc.userModePrefix(user, this.ml.buffer);
+        },
+    },
+};
+</script>
+
+<style lang="less">
+
+.kiwi-messagelist-message--text {
+    position: relative;
+}
+
+.kiwi-messagelist-message--text .kiwi-messagelist-time {
+    display: inline-block;
+}
+
+.kiwi-messagelist-message--text .kiwi-messagelist-nick {
+    display: inline-block;
+    min-width: none;
+    text-align: left;
+    max-width: 110px;
+    overflow: hidden;
+    margin-right: 10px;
+}
+
+.kiwi-messagelist-message--text .kiwi-messagelist-nick:hover {
+    max-width: none;
+    width: auto;
+}
+
+.kiwi-messagelist-message--text .kiwi-messagelist-body {
+    display: block;
+    width: 100%;
+    padding: 0;
+}
+
+.kiwi-messagelist-message--text .kiwi-messagelist-body a {
+    word-break: break-all;
+}
+
+.kiwi-messagelist-message--text.kiwi-messagelist-message-traffic {
+    padding: 0 20px 0 12px;
+}
+
+.kiwi-messagelist-message--text.kiwi-messagelist-message-traffic .kiwi-messagelist-time {
+    position: static;
+    display: inline-block;
+    top: auto;
+    right: auto;
+    margin-right: 10px;
+}
+
+.kiwi-messagelist-message--text .kiwi-messagelist-message-privmsg:hover,
+.kiwi-messagelist-message--text .kiwi-messagelist-message-action:hover,
+.kiwi-messagelist-message--text .kiwi-messagelist-message-notice:hover, {
+    cursor: pointer;
+}
+
+//Channel Connection's
+.kiwi-messagelist-message--text.kiwi-messagelist-message-connection {
+    text-align: center;
+    padding: 10px 0;
+    margin: 0;
+}
+
+.kiwi-messagelist-message--text.kiwi-messagelist-message-connection .kiwi-messagelist-body {
+    display: inline-block;
+    padding: 0;
+    margin: 0;
+}
+
+//Channel topic
+.kiwi-messagelist-message--text.kiwi-messagelist-message-topic {
+    border-radius: 0;
+    border-left: 0;
+    border-right: 0;
+    margin: 0;
+    padding: 0;
+}
+
+.kiwi-messagelist-message--text.kiwi-messagelist-message-topic .kiwi-messagelist-body {
+    padding-right: 0;
+    max-width: 95%;
+    margin-left: 20px;
+}
+
+// Traffic messages have an opacity lower than 1, so we do a blanket statment to make sure all messages are opacity: 1, rather than just specifying one.
+.kiwi-messagelist-message--text.kiwi-messagelist-message--unread {
+    opacity: 1;
+}
+
+.kiwi-messagelist-message--text .kiwi-messagelist-message-traffic .kiwi-messagelist-nick {
+    display: none;
+}
+
+.kiwi-messagelist-item:last-of-type {
+    margin-bottom: 5px;
+}
+
+</style>

--- a/src/res/globalStyle.css
+++ b/src/res/globalStyle.css
@@ -66,6 +66,15 @@ div {
 }
 
 /* Style all form inputs */
+.u-form select {
+    display: block;
+    width: 100%;
+    height: 40px;
+    padding: 0 10px;
+    cursor: pointer;
+    margin: 0 0 10px 0;
+}
+
 .u-form input[type='checkbox'],
 .u-form input[type='radio'] {
     float: left;


### PR DESCRIPTION
This PR deals with a few changes to Kiwi, most notably, it's my first draft of the 'Text' dispaly for MessageList. MessageListText is meant to display similar to modern chat rooms on video streaming websites.

- Added in new MessageListText component
- Select components have now been styled ( yay ! )
- Completely rewrote how the layout is displayed in the app settings. Rather than having an enable, disable option for Traditional, we now all users to select from a drop down list their preferred layout.

Note: This does not include translation strings for the new select. These will come in a separate PR.
