### PR TITLE
Remove auto capitalize from Kiwi - #347

### DIFF
--- a/src/components/ContainerHeader.vue
+++ b/src/components/ContainerHeader.vue
@@ -244,7 +244,6 @@ export default {
     font-size: 0.8em;
     opacity: 0.9;
     font-weight: 900;
-    text-transform: capitalize;
 }
 
 .kiwi-header-option a {

--- a/src/components/StateBrowser.vue
+++ b/src/components/StateBrowser.vue
@@ -296,7 +296,6 @@ export default {
 .kiwi-statebrowser-network .kiwi-statebrowser-network-header a {
     text-align: left;
     padding: 0 0 0 10px;
-    text-transform: capitalize;
     width: 100%;
     font-size: 1em;
     font-weight: 600;
@@ -439,7 +438,6 @@ export default {
 .kiwi-statebrowser-availablenetworks-name {
     text-align: center;
     font-weight: bold;
-    text-transform: capitalize;
 }
 
 .kiwi-statebrowser-availablenetworks-networks {

--- a/src/components/UserBox.vue
+++ b/src/components/UserBox.vue
@@ -317,7 +317,6 @@ export default {
     font-size: 1em;
     line-height: 1em;
     padding: 0;
-    text-transform: capitalize;
     text-align: left;
     opacity: 0.5;
     font-weight: 900;


### PR DESCRIPTION
- removed all instances of text-transform: capitalize.

Special thanks to @tonnesM for spotting this :) 