### PR TITLE
Globally style close icons

### DIFF
--- a/src/components/StateBrowser.vue
+++ b/src/components/StateBrowser.vue
@@ -17,7 +17,7 @@
             <div v-if="is_usermenu_open" class="kiwi-statebrowser-usermenu-body">
                 <p> {{$t('state_remembered')}} </p>
                 <a @click="clickForget" class="u-link">{{$t('state_forget')}}</a>
-                <div class="close-icon" @click="is_usermenu_open=false">
+                <div class="kiwi-close-icon" @click="is_usermenu_open=false">
                   <i class="fa fa-times" aria-hidden="true"></i>
                 </div>
             </div>
@@ -375,16 +375,6 @@ export default {
 
 .kiwi-statebrowser-usermenu-body a:hover {
     text-decoration: underline;
-}
-
-.kiwi-statebrowser-usermenu-body .close-icon {
-    position: absolute;
-    right: 0;
-    top: 0;
-    cursor: pointer;
-    padding: 0.2em 0.4em;
-    border-radius: 0 0 0 0.4em;
-    transition: all 0.3s;
 }
 
 .kiwi-statebrowser-scrollarea {

--- a/src/res/globalStyle.css
+++ b/src/res/globalStyle.css
@@ -175,6 +175,22 @@ div {
     display: inline-block;
 }
 
+/* Globally style the close icon */
+.kiwi-close-icon {
+    background-color: #fc6262;
+    color: #fff;
+    border-radius: 0 0 0 4px;
+    position: absolute;
+    right: 0;
+    top: 0;
+    cursor: pointer;
+    padding: 0.2em 0.4em;
+}
+
+.kiwi-close-icon:hover {
+    background-color: #fe7575;
+}
+
 .irc-fg-colour-white { color: #fff; }
 .irc-fg-colour-black { color: #000; }
 .irc-fg-colour-blue { color: #00f; }

--- a/static/themes/dark/theme.css
+++ b/static/themes/dark/theme.css
@@ -1232,7 +1232,6 @@
     top: 0;
     cursor: pointer;
     padding: 0.2em 0.4em;
-    border-radius: 0 0 0 0.4em;
 }
 .kiwi-close-icon:hover {
     background-color: #fe7575;

--- a/static/themes/dark/theme.css
+++ b/static/themes/dark/theme.css
@@ -1006,15 +1006,6 @@
     color: #dedede;
 }
 
-.kiwi-statebrowser-usermenu-body .close-icon {
-    background-color: #fc6262;
-    color: #dedede;
-}
-
-.kiwi-statebrowser-usermenu-body .close-icon:hover {
-    background-color: #fe7575;
-}
-
 .kiwi-statebrowser-switcher a:first-of-type {
     background: rgba(255, 255, 255, 0.15);
 }
@@ -1229,4 +1220,20 @@
 /* MOTD */
 .kiwi-messagelist-message-motd {
     color: #666;
+}
+
+/* Global Close Icons */
+.kiwi-close-icon {
+    background-color: #fc6262;
+    color: #fff;
+    border-radius: 0 0 0 4px;
+    position: absolute;
+    right: 0;
+    top: 0;
+    cursor: pointer;
+    padding: 0.2em 0.4em;
+    border-radius: 0 0 0 0.4em;
+}
+.kiwi-close-icon:hover {
+    background-color: #fe7575;
 }

--- a/static/themes/dark/theme.css
+++ b/static/themes/dark/theme.css
@@ -5,58 +5,58 @@
  */
 
 .kiwi-wrap {
-    background: #201F1F;
+    background: #201f1f;
     color: #dedede;
+
     --kiwi-nick-brightness: 50;
     --kiwi-supports-monospace: 1;
 }
 
- /* Welcome Screen ( Welcome.vue ) */
- .kiwi-welcome-simple-form,
- .kiwi-customserver-form {
-     background-color: #ffffff;
-     color: #000;
-     border: 1px solid #ececec;
- }
+/* Welcome Screen ( Welcome.vue ) */
+.kiwi-welcome-simple-form,
+.kiwi-customserver-form {
+    background-color: #fff;
+    color: #000;
+    border: 1px solid #ececec;
+}
 
- .kiwi-welcome-simple-form .input-text {
-     background: #fff;
- }
+.kiwi-welcome-simple-form .input-text {
+    background: #fff;
+}
 
- .kiwi-welcome-simple-error {
-     border: 1px dashed #d86f6f;
- }
+.kiwi-welcome-simple-error {
+    border: 1px dashed #d86f6f;
+}
 
- .kiwi-welcome-simple-form .u-submit {
-     background-color: #42b992;
-     color: #dedede;
- }
+.kiwi-welcome-simple-form .u-submit {
+    background-color: #42b992;
+    color: #dedede;
+}
 
- .kiwi-welcome-simple .help {
-     color: #666;
- }
+.kiwi-welcome-simple .help {
+    color: #666;
+}
 
- .kiwi-welcome-simple .help a {
-     color: #666;
- }
+.kiwi-welcome-simple .help a {
+    color: #666;
+}
 
- .kiwi-welcome-simple .help a:hover {
-     color: #a9d87a;
- }
+.kiwi-welcome-simple .help a:hover {
+    color: #a9d87a;
+}
 
- .kiwi-customserver {
- 	background-color: #fbfbfb;
- }
+.kiwi-customserver {
+    background-color: #fbfbfb;
+}
 
- /* ZNC startup screen */
- .kiwi-welcome-znc h2 {
-   color: #000;
- }
+/* ZNC startup screen */
+.kiwi-welcome-znc h2 {
+    color: #000;
+}
 
- .kiwi-welcome-znc .input-text {
-   background: #fff;
- }
-
+.kiwi-welcome-znc .input-text {
+    background: #fff;
+}
 
 /* App ( App.vue ) */
 .kiwi-workspace {
@@ -67,7 +67,7 @@
     background: #42b992;
 }
 
-.kiwi-workspace::after{
+.kiwi-workspace::after {
     background-color: rgba(255, 255, 255, 0.4);
 }
 
@@ -87,11 +87,11 @@
 }
 
 .u-tabbed-view-tabs .u-tabbed-view-tab:hover,
-.u-tabbed-view-tabs .u-tabbed-view-tab.u-tabbed-view-tab--active{
+.u-tabbed-view-tabs .u-tabbed-view-tab.u-tabbed-view-tab--active {
     border-bottom: 3px solid #42b992;
 }
 
-/*Style all inputs */
+/* Style all inputs */
 .input-text {
     background: #dedede;
 }
@@ -134,16 +134,11 @@
 .u-form input[type='checkbox'],
 .u-form input[type='radio'] {
     border: 2px solid #000;
-    background-color: #ffffff;
+    background-color: #fff;
 }
 
-.u-form input[type='checkbox']:after,
-.u-form input[type='radio']:after {
-    background: #42b992;
-}
-
-.u-form input[type='checkbox']:after,
-.u-form input[type='radio']:after {
+.u-form input[type='checkbox']::after,
+.u-form input[type='radio']::after {
     background: #42b992;
 }
 
@@ -156,7 +151,7 @@
     border: 1px solid #42b992;
 }
 
-/*buttons */
+/* buttons */
 .u-button {
     color: #2c3e50;
     text-shadow: 0 1px 1px rgba(255, 255, 255, 0.1);
@@ -184,7 +179,6 @@
     color: #fff;
 }
 
-
 /* Application settings ( AppSettings.vue ) */
 .kiwi-appsettings {
     background: #1e1e1e;
@@ -209,7 +203,7 @@
     color: #fff;
 }
 
-.kiwi-appsettings-title:hover{
+.kiwi-appsettings-title:hover {
     background: #d16c6c;
 }
 
@@ -217,7 +211,7 @@
 .kiwi-autocomplete {
     box-shadow: 0 1px 15px rgba(64, 54, 63, 0.25);
     border: 1px solid #ccc;
-    background: #201F1F;
+    background: #201f1f;
     color: #fff;
 }
 
@@ -291,7 +285,8 @@
 }
 
 .kiwi-userbox .kiwi-userbox-actions {
-    color: #dedede;
+    color: #fff;
+    border-color: #fff;
 }
 
 .kiwi-userbox .kiwi-userbox-actions .u-button {
@@ -333,10 +328,6 @@
     color: #dedede;
 }
 
-.kiwi-header-buffersettings {
-    border-top: 1px solid #ddd;
-}
-
 .kiwi-header-option {
     border-left: 1px solid rgba(255, 255, 255, 0.2);
 }
@@ -365,7 +356,7 @@
     background-color: #22231f;
 }
 
-.kiwi-statebrowser-channel-settings:hover{
+.kiwi-statebrowser-channel-settings:hover {
     background-color: #42b992;
 }
 
@@ -467,19 +458,19 @@
     color: #fff;
 }
 
-/*Container Header */
+/* Container Header */
 .control-input {
     background: #1e1e1e;
     color: #dedede;
 }
 
-.kiwi-messagelist-message--highlight{
-    background-color: #333333;
+.kiwi-messagelist-message--highlight {
+    background-color: #333;
 }
 
-/*When hovering over a users messages */
-.kiwi-messagelist-message--hover{
-    background-color: #333333;
+/* When hovering over a users messages */
+.kiwi-messagelist-message--hover {
+    background-color: #333;
 }
 
 .kiwi-messagelist-message--modern .kiwi-messagelist-body {
@@ -500,7 +491,7 @@
     color: #fff;
 }
 
-/*Sidebar*/
+/* Sidebar */
 .kiwi-sidebar {
     background: #1e1e1e;
 }
@@ -510,10 +501,12 @@
     background-color: #42b992;
     color: #fff;
 }
+
 .kiwi-sidebar-pin {
     border-right: 1px solid #fff;
     background: #42b992;
 }
+
 .kiwi-sidebar-pin:hover {
     background: #62d0ac;
 }
@@ -521,6 +514,7 @@
 .kiwi-sidebar-options .kiwi-sidebar-close:hover {
     background: #d16c6c;
 }
+
 .kiwi-container--sidebar-pinned .kiwi-sidebar {
     border-color: #b2b2b2;
 }
@@ -531,7 +525,6 @@
 .kiwi-channelbanlist-table {
     color: #fff;
 }
-
 
 /* Style the banlist */
 .kiwi-channelbanlist-table-actions:hover {
@@ -545,7 +538,7 @@
 /* Topic Styling */
 .kiwi-messagelist-message--compact.kiwi-messagelist-message-topic,
 .kiwi-messagelist-message--modern.kiwi-messagelist-message-topic {
-    background: rgba(0,0,0,0.02);
+    background: rgba(0, 0, 0, 0.02);
     border: 2px solid #42b992;
     color: #dedede;
 }
@@ -580,17 +573,17 @@
     color: #000;
 }
 
-
 /* Kiwi Modern Message list ( MessageListMessageModern.vue ) */
 .kiwi-messagelist-modern-avatar {
     border: 2px solid #42b992;
 }
+
 .kiwi-messagelist-nick {
     color: #000;
 }
 
 .kiwi-messagelist-message--compact .kiwi-messagelist-nick:hover {
-    background-color: #333333;
+    background-color: #333;
 }
 
 .kiwi-messagelist-time {
@@ -598,11 +591,11 @@
 }
 
 .kiwi-messagelist-message--modern {
-  border-top: 1px solid #ffffff;
+    border-top: 1px solid #fff;
 }
 
 .kiwi-messagelist-message--modern.kiwi-messagelist-message--authorrepeat {
-  border-top: none;
+    border-top: none;
 }
 
 .kiwi-messagelist-message--modern.kiwi-messagelist-message-topic.kiwi-messagelist-message--unread {
@@ -610,17 +603,16 @@
 }
 
 .kiwi-messagelist-message--modern.kiwi-messagelist-message-topic {
-  border-bottom: 2px solid #42b992;
+    border-bottom: 2px solid #42b992;
 }
 
 .kiwi-messagelist-message--modern.kiwi-messagelist-message--authorrepeat.kiwi-messagelist-message-topic {
     border-top: 2px solid #42b992;
 }
 
-
 .kiwi-messagelist-message--compact .kiwi-messagelist-message-privmsg:hover,
 .kiwi-messagelist-message--compact .kiwi-messagelist-message-action:hover,
-.kiwi-messagelist-message--compact .kiwi-messagelist-message-notice:hover, {
+.kiwi-messagelist-message--compact .kiwi-messagelist-message-notice:hover {
     cursor: pointer;
     border-left-color: #80ab52;
 }
@@ -645,10 +637,6 @@
     background: #dedede;
 }
 
-.kiwi-networksettings .u-form {
-    border: 1px solid rgba(0, 0, 0, 0.2);
-}
-
 .kiwi-networksettings input[type='text'],
 .kiwi-networksettings input[type='password'],
 .kiwi-networksettings input[type='email'],
@@ -665,6 +653,7 @@
 .kiwi-networksettings .u-form {
     background: rgb(62, 62, 62);
     color: #dedede;
+    border: 1px solid rgba(0, 0, 0, 0.2);
 }
 
 .kiwi-networksettings .u-form .input-text {
@@ -689,15 +678,15 @@
     color: #fff;
 }
 
-.kiwi-networksettings  .kiwi-customserver-tls--enabled {
+.kiwi-networksettings .kiwi-customserver-tls--enabled {
     color: green;
 }
 
-.kiwi-networksettings  .kiwi-customserver-tls--enabled .kiwi-customserver-tls-lock {
+.kiwi-networksettings .kiwi-customserver-tls--enabled .kiwi-customserver-tls-lock {
     color: green;
 }
 
-.kiwi-networksettings  .kiwi-customserver-tls-minus {
+.kiwi-networksettings .kiwi-customserver-tls-minus {
     color: red;
 }
 
@@ -713,7 +702,7 @@
 }
 
 .u-button.kiwi-channellist-refresh.u-button-secondary {
-  background: #42b992;
+    background: #42b992;
 }
 
 /* Nicklist ( Nicklist.vu ) */
@@ -739,13 +728,8 @@
     border-top: none;
 }
 
-.kiwi-nicklist-user:after {
+.kiwi-nicklist-user::after {
     color: #666764;
-}
-
-.kiwi-nicklist-user:hover {
-    background-color: #42b992;
-    color: #dedede;
 }
 
 .kiwi-nicklist-user:hover {
@@ -755,11 +739,11 @@
 }
 
 .kiwi-nicklist-user:hover .kiwi-nicklist-user-nick {
-    color: #333333 !important;
+    color: #333 !important;
 }
 
-.kiwi-nicklist-user:hover .kiwi-nicklist-user-nick:after {
-    color: #333333;
+.kiwi-nicklist-user:hover .kiwi-nicklist-user-nick::after {
+    color: #333;
 }
 
 .kiwi-nicklist-messageuser {
@@ -781,7 +765,7 @@
     color: #dedede;
 }
 
-.kiwi-notconnected-button:hover{
+.kiwi-notconnected-button:hover {
     background-color: #dedede;
     color: #000;
 }
@@ -815,7 +799,7 @@
 }
 
 .kiwi-settings-aliases-help {
-    background: transparent
+    background: transparent;
     border: 1px dashed gray;
 }
 
@@ -823,8 +807,6 @@
     color: #42b992;
     font-weight: 900;
 }
-
-
 
 /* Statebrowser - Left sidebar ( StateBrowser.vue ) */
 .kiwi-statebrowser {
@@ -918,7 +900,7 @@
     background-color: #131312;
 }
 
-/*Channel search input */
+/* Channel search input */
 .kiwi-statebrowser-channelfilter {
     transition: all 0.3s;
     border-bottom: 1px solid rgba(255, 255, 255, 0.5);
@@ -973,16 +955,16 @@
 }
 
 /* Channel Styling */
-.kiwi-statebrowser-channels  .kiwi-statebrowser-channel {
+.kiwi-statebrowser-channels .kiwi-statebrowser-channel {
     border-bottom: 1px solid #4a4b47;
     color: #dedede;
 }
 
-.kiwi-statebrowser-channels  .kiwi-statebrowser-channel .kiwi-statebrowser-channel-name {
+.kiwi-statebrowser-channels .kiwi-statebrowser-channel .kiwi-statebrowser-channel-name {
     color: #dedede;
 }
 
-.kiwi-statebrowser-channels  .kiwi-statebrowser-channel .kiwi-statebrowser-channel-name  .kiwi-statebrowser-channel-label {
+.kiwi-statebrowser-channels .kiwi-statebrowser-channel .kiwi-statebrowser-channel-name .kiwi-statebrowser-channel-label {
     background: #d16c6c;
 }
 
@@ -993,7 +975,6 @@
 .kiwi-search-channels.active{
     background: #42b992;
 }
-
 
 /* New Channel Button */
 .kiwi-statebrowser-newchannel a {
@@ -1013,7 +994,6 @@
 .kiwi-statebrowser-switcher a:hover {
     background: rgba(255, 255, 255, 0.1);
 }
-
 
 .kiwi-statebrowser-options {
     background: #383838;
@@ -1053,7 +1033,7 @@
 }
 
 .kiwi-statebrowser-channel-label--highlight {
-    background: #e45e5e;
+    background: #d62323;
 }
 
 .kiwi-statebrowser-channel-popup {
@@ -1103,10 +1083,6 @@
     color: #dedede;
 }
 
-.kiwi-statebrowser-channel-label--highlight {
-    background: #d62323;
-}
-
 .kiwi-statebrowser-channel-popup {
     background: #383838;
     border: 3px solid #6b6b6b;
@@ -1125,7 +1101,6 @@
     background: rgba(255, 255, 255, 0.05);
 }
 
-
 /* User Box Styling ( UserBox.vue ) */
 .kiwi-userbox-usermask {
     color: #9e9e9e;
@@ -1136,7 +1111,7 @@
 }
 
 .kiwi-userbox-opactions label select {
-    border: 1px solid rgba(0, 0, 0, 0.2);
+    border: 1px solid rgba(255, 255, 255, 0.2);
 }
 
 .kiwi-userbox .main-title {
@@ -1145,14 +1120,6 @@
 
 .kiwi-userbox .kiwi-userbox-basicinfo {
     border-bottom: 1px solid rgba(255, 255, 255, 0.2);
-}
-
-.kiwi-userbox-opactions {
-    border-top: 1px solid #9e9e9e;
-}
-
-.kiwi-userbox-opactions label select {
-    border: 1px solid rgba(255, 255, 255, 0.2);
 }
 
 .kiwi-userbox-opaction-kick ,
@@ -1173,15 +1140,15 @@
     background-color: #fcb46e;
 }
 
-.kiwi-userbox-opaction-ban:hover{
+.kiwi-userbox-opaction-ban:hover {
     background-color: #ffca97;
 }
 
-.kiwi-userbox-opaction-kickban{
+.kiwi-userbox-opaction-kickban {
     background-color: #fb846a;
 }
 
-.kiwi-userbox-opaction-kickban:hover{
+.kiwi-userbox-opaction-kickban:hover {
     background-color: #ffaf9e;
 }
 
@@ -1190,19 +1157,14 @@
     border-radius: 2px;
 }
 
-.kiwi-userbox .kiwi-userbox-actions {
-    color: #fff;
-    border-color: #fff;
-}
-
 .kiwi-userbox-actions .kiwi-userbox-action {
     color: rgba(255, 255, 255, 0.7);
     border-color: rgba(255, 255, 255, 0.7);
 }
 
 .kiwi-userbox-actions .kiwi-userbox-action:hover {
-  color: rgba(255, 255, 255, 1);
-  border-color: rgba(255, 255, 255, 1);
+    color: rgba(255, 255, 255, 1);
+    border-color: rgba(255, 255, 255, 1);
 }
 
 .kiwi-messagelist-message-whois {
@@ -1220,19 +1182,4 @@
 /* MOTD */
 .kiwi-messagelist-message-motd {
     color: #666;
-}
-
-/* Global Close Icons */
-.kiwi-close-icon {
-    background-color: #fc6262;
-    color: #fff;
-    border-radius: 0 0 0 4px;
-    position: absolute;
-    right: 0;
-    top: 0;
-    cursor: pointer;
-    padding: 0.2em 0.4em;
-}
-.kiwi-close-icon:hover {
-    background-color: #fe7575;
 }

--- a/static/themes/default/theme.css
+++ b/static/themes/default/theme.css
@@ -807,14 +807,6 @@
     color: #fff;
 }
 
-.kiwi-statebrowser-usermenu-body .close-icon {
-    background-color: #fc6262;
-    color: #fff;
-}
-.kiwi-statebrowser-usermenu-body .close-icon:hover {
-    background-color: #fe7575;
-}
-
 .kiwi-statebrowser-switcher a:first-of-type {
     background: rgba(255, 255, 255, 0.15);
 }
@@ -969,4 +961,20 @@
 /* MOTD */
 .kiwi-messagelist-message-motd {
     color: #666;
+}
+
+/* Global Close Icons */
+.kiwi-close-icon {
+    background-color: #fc6262;
+    color: #fff;
+    border-radius: 0 0 0 4px;
+    position: absolute;
+    right: 0;
+    top: 0;
+    cursor: pointer;
+    padding: 0.2em 0.4em;
+    border-radius: 0 0 0 0.4em;
+}
+.kiwi-close-icon:hover {
+    background-color: #fe7575;
 }

--- a/static/themes/default/theme.css
+++ b/static/themes/default/theme.css
@@ -962,18 +962,3 @@
 .kiwi-messagelist-message-motd {
     color: #666;
 }
-
-/* Global Close Icons */
-.kiwi-close-icon {
-    background-color: #fc6262;
-    color: #fff;
-    border-radius: 0 0 0 4px;
-    position: absolute;
-    right: 0;
-    top: 0;
-    cursor: pointer;
-    padding: 0.2em 0.4em;
-}
-.kiwi-close-icon:hover {
-    background-color: #fe7575;
-}

--- a/static/themes/default/theme.css
+++ b/static/themes/default/theme.css
@@ -973,7 +973,6 @@
     top: 0;
     cursor: pointer;
     padding: 0.2em 0.4em;
-    border-radius: 0 0 0 0.4em;
 }
 .kiwi-close-icon:hover {
     background-color: #fe7575;


### PR DESCRIPTION
Close icons are now globally styled with the class 'kiwi-close-icon'. This is meant to be merged with #393 to ensure it is styled correctly 