### PR TITLE
Remove user from network state when no remaining shared buffers #397

### DIFF
--- a/src/libs/IrcClient.js
+++ b/src/libs/IrcClient.js
@@ -443,6 +443,14 @@ function clientMiddleware(state, networkid) {
                 buffer.clearUsers();
             }
 
+            // Remove the user from network state if no remaining common channels
+            let remainingBuffers = state.getBuffersWithUser(networkid, event.nick);
+            if (remainingBuffers.length === 0) {
+                state.removeUser(networkid, {
+                    nick: event.nick,
+                });
+            }
+
             let messageBody = TextFormatting.formatAndT(
                 'channel_part',
                 { reason: event.message },

--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -568,8 +568,8 @@ const state = new Vue({
                     if (newVal === null) {
                         this.$delete(val, propName, newVal);
                     } else {
-                        this.$set(val, propName, newVal);
-                    }
+                    this.$set(val, propName, newVal);
+                }
                 }
 
                 val = nextVal;
@@ -738,8 +738,8 @@ const state = new Vue({
                         targetBuffer = buffer;
                     } else {
                         targetBuffer = network.serverBuffer();
-                    }
                 }
+            }
             }
 
             if (targetBuffer) {
@@ -841,6 +841,16 @@ const state = new Vue({
 
             if (buffer.isChannel() && buffer.joined) {
                 network.ircClient.part(buffer.name);
+            }
+
+            // Remove the user from network state if no remaining common channels
+            if (buffer.isQuery()) {
+                let remainingBuffers = state.getBuffersWithUser(network.id, buffer.name);
+                if (remainingBuffers.length === 0) {
+                    state.removeUser(network.d, {
+                        nick: buffer.name,
+                    });
+                }
             }
 
             if (isActiveBuffer) {
@@ -1126,7 +1136,7 @@ const state = new Vue({
             let normalisedNick = nick.toLowerCase();
             let buffers = [];
             network.buffers.forEach((buffer) => {
-                if (buffer.users[normalisedNick] || buffer.name === nick) {
+                if (buffer.users[normalisedNick] || normalisedNick === buffer.name.toLowerCase()) {
                     buffers.push(buffer);
                 } else if (nick === network.nick && buffer.isQuery()) {
                     buffers.push(buffer);

--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -568,8 +568,8 @@ const state = new Vue({
                     if (newVal === null) {
                         this.$delete(val, propName, newVal);
                     } else {
-                    this.$set(val, propName, newVal);
-                }
+                        this.$set(val, propName, newVal);
+                    }
                 }
 
                 val = nextVal;
@@ -738,8 +738,8 @@ const state = new Vue({
                         targetBuffer = buffer;
                     } else {
                         targetBuffer = network.serverBuffer();
+                    }
                 }
-            }
             }
 
             if (targetBuffer) {
@@ -1108,6 +1108,13 @@ const state = new Vue({
 
             if (!userObj) {
                 userObj = this.addUser(network, user);
+            } else {
+                // Verify the user object is correct
+                _.each(user, (val, prop) => {
+                    if (userObj[prop] !== val) {
+                        userObj[prop] = val;
+                    }
+                });
             }
 
             buffer.addUser(userObj);


### PR DESCRIPTION
When there is no common channels, things like quit, nick change etc go unseen by the client.

Fix this by removing users from the network state when they no longer share a common channel

Fixes #397