### PR TITLE
Create a default FallbackComponent

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -20,7 +20,7 @@
             <div class="kiwi-workspace" @click="stateBrowserDrawOpen = false">
                 <div class="kiwi-workspace-background"></div>
 
-                <template v-if="!activeComponent && network">
+                <template v-if="!activeComponent && network && buffer">
                     <container
                         :network="network"
                         :buffer="buffer"
@@ -60,6 +60,7 @@ import startupCustomServer from '@/components/startups/CustomServer';
 import startupKiwiBnc from '@/components/startups/KiwiBnc';
 import startupPersonal from '@/components/startups/Personal';
 import StateBrowser from '@/components/StateBrowser';
+import FallbackComponent from '@/components/FallbackComponent';
 import Container from '@/components/Container';
 import ControlInput from '@/components/ControlInput';
 import MediaViewer from '@/components/MediaViewer';
@@ -271,6 +272,7 @@ export default {
     },
     components: {
         StateBrowser,
+        FallbackComponent,
         Container,
         ControlInput,
         MediaViewer,
@@ -286,7 +288,7 @@ export default {
             activeComponentProps: {},
             // If set, will become the main view when no networks are available to be shown
             // and there is no active component set
-            fallbackComponent: null,
+            fallbackComponent: FallbackComponent,
             fallbackComponentProps: {},
             mediaviewerOpen: false,
             mediaviewerUrl: '',

--- a/src/components/Container.vue
+++ b/src/components/Container.vue
@@ -5,7 +5,7 @@
             'kiwi-container--sidebar-pinned': uiState.isPinned,
             'kiwi-container--no-sidebar': buffer && !buffer.isChannel,
     }">
-        <template v-if="buffer">
+        <template>
             <div @click.stop="toggleStateBrowser" class="kiwi-container-toggledraw-statebrowser">
                 <div
                     class="kiwi-container-toggledraw-statebrowser-messagecount kiwi-container-toggledraw-statebrowser-messagecount--highlight"
@@ -31,12 +31,6 @@
                 </template>
 
                 <slot name="after"></slot>
-            </div>
-        </template>
-        <template v-else>
-            <div class="kiwi-container-empty">
-                <h4>{{$t('container_welcome')}}</h4>
-                <a @click.stop="toggleStateBrowser" class="u-button">{{$t('container_statebrowser')}}</a>
             </div>
         </template>
     </div>
@@ -223,18 +217,6 @@ export default {
     left: 6px;
     width: 37px;
     padding: 0;
-}
-
-.kiwi-container-empty {
-    text-align: center;
-    padding: 1em;
-}
-
-.kiwi-container-empty .u-button {
-    border-radius: 3px;
-    font-weight: 500;
-    line-height: 50px;
-    padding: 0 14px;
 }
 
 @media screen and (max-width: 1500px) {

--- a/src/components/FallbackComponent.vue
+++ b/src/components/FallbackComponent.vue
@@ -1,0 +1,33 @@
+<template>
+    <div class="kiwi-fallback-container">
+        <h4>{{$t('container_welcome')}}</h4>
+        <a @click.stop="toggleStateBrowser" class="u-button">{{$t('container_statebrowser')}}</a>
+    </div>
+</template>
+
+<script>
+
+import state from '@/libs/state';
+
+export default {
+    methods: {
+        toggleStateBrowser: function toggleStateBrowser() {
+            state.$emit('statebrowser.toggle');
+        },
+    },
+};
+</script>
+
+<style>
+.kiwi-fallback-container {
+    text-align: center;
+    padding: 1em;
+}
+
+.kiwi-fallback-container .u-button {
+    border-radius: 3px;
+    font-weight: 500;
+    line-height: 50px;
+    padding: 0 14px;
+}
+</style>

--- a/static/themes/dark/theme.css
+++ b/static/themes/dark/theme.css
@@ -462,7 +462,7 @@
     color: #3a99e1;
 }
 
-.kiwi-container-empty .u-button {
+.kiwi-fallback-container .u-button {
     background-color: #42b992;
     color: #fff;
 }

--- a/static/themes/default/theme.css
+++ b/static/themes/default/theme.css
@@ -223,7 +223,7 @@
     border-right-color: #d62323;
 }
 
-.kiwi-container-empty .u-button {
+.kiwi-fallback-container .u-button {
     background-color: #42b992;
     color: #fff;
 }


### PR DESCRIPTION
This hopefully will solve the issue of the input being shown when there is no buffer due to kiwi-container-empty being shown

kiwi-container-empty has now been moved to FallbackComponent.

**Due to limited time testing of this commit has been limited**