### PR TITLE
Fix: Traditional layout, connection and disconnect messages centered

### DIFF
--- a/src/components/MessageListMessageCompact.vue
+++ b/src/components/MessageListMessageCompact.vue
@@ -221,6 +221,7 @@ export default {
         float: left;
         width: 100%;
         margin-left: 0;
+        box-sizing: border-box;
     }
 
     .kiwi-messagelist-message--compact.kiwi-messagelist-message--unread .kiwi-messagelist-body {


### PR DESCRIPTION
This PR simply adds border box to compact message list items on mobile screens, causing the connection messages to be centered. In response to #448  :) 