### PR TITLE
Fix: Container Header add close icon for 'Special' view #389

### DIFF
--- a/src/components/ContainerHeader.vue
+++ b/src/components/ContainerHeader.vue
@@ -126,9 +126,11 @@
 
         <template v-else-if="isSpecial()">
             <div class="kiwi-header-options">
-                <a class="u-button u-button-secondary" @click="closeCurrentBuffer">
-                    {{ $t('close') }}
-                </a>
+                <div class="kiwi-header-option kiwi-header-option-leave">
+                    <a @click="closeCurrentBuffer">
+                        <i class="fa fa-times" aria-hidden="true"/>
+                    </a>
+                </div>
             </div>
             <div class="kiwi-header-name">{{ buffer.name }}</div>
         </template>


### PR DESCRIPTION
- Fixes #389  Add a standard close icon to the 'special' query in containerHeader.