### PR TITLE
Correct channel list white text on white background

### DIFF
--- a/static/themes/coffee/theme.css
+++ b/static/themes/coffee/theme.css
@@ -139,7 +139,7 @@
     color: #fff;
 }
 .u-link {
-    color: #fff;
+    color: #91735d;
 }
 
 /* Application settings ( AppSettings.vue ) */

--- a/static/themes/grayfox/theme.css
+++ b/static/themes/grayfox/theme.css
@@ -140,7 +140,7 @@
     color: #fff;
 }
 .u-link {
-    color: #fff;
+    color: #848d99;
 }
 
 /* Application settings ( AppSettings.vue ) */


### PR DESCRIPTION
Fix #474 u-link font colors for coffee and grayfox themes.