### PR TITLE
make emitBufferPaste a capturing listener

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -8,7 +8,7 @@
         :data-activebuffer="buffer ? buffer.name.toLowerCase() : ''"
         class="kiwi-wrap kiwi-theme-bg"
         @click="emitDocumentClick"
-        @paste="emitBufferPaste"
+        @paste.capture="emitBufferPaste"
     >
         <link :href="themeUrl" rel="stylesheet" type="text/css">
 


### PR DESCRIPTION
this is necessary so that plugins can prevent core paste
handlers from firing, such as the one in IrcInput