### PR TITLE
Themes: Osprey link colour update

### DIFF
--- a/static/themes/osprey/theme.css
+++ b/static/themes/osprey/theme.css
@@ -148,7 +148,7 @@
     color: #fff;
 }
 .u-link {
-    color: #fff;
+    color: #4d6075;
 }
 
 /* Application settings ( AppSettings.vue ) */


### PR DESCRIPTION
- Simply change to make links on Osprey visible, previously they were white, now they are the 'Osprey' primary colour.