### PR TITLE
FIX: #564 - Nicklist unpinned width fix

### DIFF
--- a/src/components/Nicklist.vue
+++ b/src/components/Nicklist.vue
@@ -192,6 +192,12 @@ export default {
 </script>
 
 <style lang="less">
+
+/* Adjust the sidebars width when this nicklist is in view */
+.kiwi-sidebar.kiwi-sidebar-section-nicklist {
+    width: 250px;
+}
+
 .kiwi-nicklist {
     overflow: hidden;
     box-sizing: border-box;

--- a/src/components/Nicklist.vue
+++ b/src/components/Nicklist.vue
@@ -192,13 +192,6 @@ export default {
 </script>
 
 <style lang="less">
-
-/* Adjust the sidebars width when this nicklist is in view */
-.kiwi-sidebar.kiwi-sidebar-section-nicklist {
-    max-width: 250px;
-    width: 250px;
-}
-
 .kiwi-nicklist {
     overflow: hidden;
     box-sizing: border-box;


### PR DESCRIPTION
- Removed the width settings on the nicklist - making the pinned and unpinned nicklist the same width, this should solve issue #564 