### PR TITLE
FIX: Settings and Close StateBrowser icon for mobile devices

### DIFF
--- a/src/components/AppSettings.vue
+++ b/src/components/AppSettings.vue
@@ -1,8 +1,7 @@
 <template>
     <div class="kiwi-appsettings">
 
-        <div class="kiwi-appsettings-title" @click="closeSettings">
-            <span>{{ $t('close') }}</span>
+        <div class="kiwi-appsettings-close" @click="closeSettings">
             <i class="fa fa-times" aria-hidden="true"/>
         </div>
 
@@ -337,8 +336,6 @@ export default {
     box-sizing: border-box;
     height: 100%;
     overflow-y: auto;
-    padding: 8px 0 0 0;
-    margin-top: -7px;
 
     .u-form {
         width: 100%;
@@ -383,10 +380,6 @@ export default {
 
 .kiwi-appsettings-tab-container {
     width: 100%;
-}
-
-.kiwi-appsettings-close {
-    float: right;
 }
 
 .kiwi-appsettings .u-form label {
@@ -442,40 +435,21 @@ export default {
     max-width: 750px;
 }
 
-.kiwi-appsettings-title {
-    display: block;
+.kiwi-appsettings-close {
+    display: inline-block;
+    position: absolute;
+    top: 7px;
+    right: 0;
+    width: auto;
     cursor: pointer;
     padding: 0 10px;
-    margin: -1px 0 0 0;
-    font-weight: 600;
-    width: 100%;
-    position: relative;
-    box-sizing: border-box;
-    text-transform: uppercase;
-    line-height: 47px;
     text-align: right;
+    box-sizing: border-box;
     transition: background 0.3s;
 }
 
-.kiwi-appsettings-title h2 {
-    padding: 10px 0 11px 20px;
-    width: auto;
-    float: left;
-}
-
-.kiwi-appsettings-title a {
-    float: right;
-    position: static;
-    background: none;
-    border: none;
-    padding: 10px 20px;
-    font-size: 1.4em;
-}
-
-.kiwi-appsettings-title i {
-    margin-left: 10px;
-    font-size: 1.5em;
-    float: right;
+.kiwi-appsettings-close i {
+    font-size: 18px;
     line-height: 47px;
 }
 
@@ -486,6 +460,14 @@ export default {
         position: fixed;
         left: 0;
         transition: left 0.5s;
+    }
+
+    .kiwi-appsettings-close {
+        top: 0;
+    }
+
+    .kiwi-appsettings-close i {
+        line-height: 45px;
     }
 
     .kiwi-appsettings .kiwi-appsettings-block {

--- a/src/components/Nicklist.vue
+++ b/src/components/Nicklist.vue
@@ -237,6 +237,10 @@ export default {
     line-height: 53px;
 }
 
+.kiwi-container--sidebar-pinned .kiwi-sidebar .kiwi-nicklist-usercount .fa-search {
+    margin-right: 15px;
+}
+
 .kiwi-nicklist-usercount .fa-search:hover,
 .kiwi-nicklist--filtering .kiwi-nicklist-usercount .fa-search {
     opacity: 1;

--- a/src/components/Nicklist.vue
+++ b/src/components/Nicklist.vue
@@ -218,8 +218,8 @@ export default {
     justify-content: space-between;
     cursor: default;
     box-sizing: border-box;
-    height: 43px;
-    line-height: 39px;
+    height: 58px;
+    line-height: 55px;
     width: 100%;
 }
 
@@ -231,10 +231,10 @@ export default {
 .kiwi-nicklist-usercount .fa-search {
     opacity: 0.3;
     cursor: pointer;
-    font-size: 1.2em;
-    padding-top: 10px;
+    font-size: 16px;
     align-self: flex-start;
-    margin-right: 15px;
+    margin-right: 75px;
+    line-height: 53px;
 }
 
 .kiwi-nicklist-usercount .fa-search:hover,
@@ -276,6 +276,20 @@ export default {
     .kiwi-sidebar.kiwi-sidebar-section-nicklist {
         width: 100%;
         max-width: 380px;
+    }
+
+    .kiwi-nicklist-usercount {
+        height: 58px;
+    }
+
+    .kiwi-nicklist-usercount span {
+        line-height: 50px;
+    }
+
+    .kiwi-nicklist-usercount .fa-search {
+        margin-right: 50px;
+        padding-top: 0;
+        line-height: 50px;
     }
 }
 

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -21,7 +21,7 @@
                         <i class="fa fa-thumb-tack" aria-hidden="true"/>
                     </div>
                     <div class="kiwi-sidebar-close" @click="sidebarState.close()">
-                        {{ $t('close') }}<i class="fa fa-times" aria-hidden="true"/>
+                        <i class="fa fa-times" aria-hidden="true"/>
                     </div>
                 </span>
 
@@ -242,38 +242,30 @@ export default {
 }
 
 .kiwi-sidebar-options {
-    display: block;
-    cursor: pointer;
+    position: absolute;
+    right: 0;
+    width: auto;
     font-weight: 600;
-    width: 100%;
-    position: relative;
     box-sizing: border-box;
     text-transform: uppercase;
-    line-height: 50px;
     vertical-align: top;
+    font-size: 0;
 }
 
-.kiwi-sidebar-options .kiwi-sidebar-pin {
-    position: absolute;
+.kiwi-sidebar-options .kiwi-sidebar-pin,
+.kiwi-sidebar-options .kiwi-sidebar-close {
+    display: inline-block;
+    cursor: pointer;
     padding: 0 10px;
-    height: 100%;
     line-height: 52px;
     z-index: 1;
+    font-size: 18px;
     transition: background 0.3s;
 }
 
-.kiwi-sidebar-options .kiwi-sidebar-close {
-    width: 100%;
-    display: inline-block;
-    padding: 0 20px 0 40px;
-    text-align: right;
-    box-sizing: border-box;
-    transition: background 0.3s;
-}
-
+.kiwi-sidebar-options .kiwi-sidebar-pin i,
 .kiwi-sidebar-options .kiwi-sidebar-close i {
-    margin-left: 10px;
-    font-size: 1.5em;
+    font-size: 0.95em;
     line-height: 47px;
 }
 
@@ -314,15 +306,6 @@ export default {
 }
 
 @media screen and (max-width: 769px) {
-    .kiwi-sidebar .u-tabbed-view-tab {
-        width: 100%;
-    }
-
-    .kiwi-sidebar .u-tabbed-view-tab.u-tabbed-view-tab--active {
-        border-bottom: 3px solid #42b992;
-        margin-bottom: 0;
-    }
-
     .kiwi-sidebar .u-form input[type="checkbox"] {
         margin-right: 4px;
     }
@@ -353,9 +336,21 @@ export default {
     .kiwi-channelbanlist .u-form {
         line-height: 10px;
     }
+}
 
-    .kiwi-sidebar-options {
-        line-height: 47px;
+@media screen and (max-width: 500px) {
+    .kiwi-sidebar .u-tabbed-view-tab {
+        width: 100%;
+    }
+
+    .kiwi-sidebar .u-tabbed-view-tab.u-tabbed-view-tab--active {
+        border-bottom: 3px solid #42b992;
+        margin-bottom: 0;
+    }
+
+    .kiwi-sidebar-options .kiwi-sidebar-pin,
+    .kiwi-sidebar-options .kiwi-sidebar-close {
+        line-height: 49px;
     }
 }
 

--- a/src/components/StateBrowser.vue
+++ b/src/components/StateBrowser.vue
@@ -6,7 +6,6 @@
         </div>
 
         <div class="kiwi-statebrowser-mobile-close" @click="hideStatebrowser">
-            <span> Close </span>
             <i class="fa fa-times" aria-hidden="true"/>
         </div>
 
@@ -567,7 +566,6 @@ export default {
     }
 
     .kiwi-statebrowser-mobile-close {
-        width: 100%;
         color: #fff;
         display: block;
         padding: 0 10px;
@@ -576,22 +574,28 @@ export default {
         box-sizing: border-box;
         margin-bottom: 0;
         text-transform: uppercase;
-        line-height: 45px;
-        height: 45px;
-
-        span {
-            float: left;
-        }
+        position: absolute;
+        border-radius: 0 0 0 2px;
+        right: 0;
+        z-index: 10;
 
         i {
             float: right;
             font-size: 1.2em;
-            line-height: 45px;
+            line-height: 50px;
         }
     }
 
     .kiwi-statebrowser-usermenu {
         position: relative;
+    }
+
+    .kiwi-statebrowser-appsettings {
+        z-index: 10;
+    }
+
+    .kiwi-statebrowser-appsettings i {
+        line-height: 50px;
     }
 }
 

--- a/src/components/StateBrowser.vue
+++ b/src/components/StateBrowser.vue
@@ -570,7 +570,7 @@ export default {
         display: block;
         padding: 0 10px;
         font-weight: 600;
-        background: #42b992;
+        background: #d16c6c;
         box-sizing: border-box;
         margin-bottom: 0;
         text-transform: uppercase;
@@ -581,7 +581,7 @@ export default {
 
         i {
             float: right;
-            font-size: 1.2em;
+            font-size: 16px;
             line-height: 50px;
         }
     }

--- a/static/themes/default/theme.css
+++ b/static/themes/default/theme.css
@@ -160,12 +160,9 @@
 }
 
 /* Title bar, at the top of the Application settings component */
-.kiwi-appsettings-title {
-    background-color: #42b992;
-    color: #fff;
-}
-.kiwi-appsettings-title:hover{
+.kiwi-appsettings-close {
     background: #d16c6c;
+    color: #fff;
 }
 
 
@@ -608,15 +605,17 @@
 
 /* Sidebar ( Sidebar.vue ) */
 .kiwi-sidebar-options {
-    background-color: #42b992;
+    background-color: #e6e6e6;
     color: #fff;
 }
 .kiwi-sidebar-pin{
-    border-right: 1px solid #fff;
     background: #42b992;
 }
 .kiwi-sidebar-pin:hover{
     background: #62d0ac;
+}
+.kiwi-sidebar-options .kiwi-sidebar-close {
+    background: #d16c6c;
 }
 .kiwi-sidebar-options .kiwi-sidebar-close:hover {
     background: #d16c6c;
@@ -625,7 +624,6 @@
 .kiwi-container--sidebar-pinned .kiwi-sidebar {
     border-color: #b2b2b2;
 }
-
 
 /* Channel Banlist ( Channelbanlist.vue ) */
 .kiwi-channelbanlist-table tr {
@@ -677,7 +675,6 @@
 
 /* User Settings */
 .kiwi-statebrowser-appsettings:hover {
-    background: #42b992;
     color: #fff;
     opacity: 1;
 }


### PR DESCRIPTION
- Remove span from close
- Close icon in statebrowser is now absolute positioned
- Close icon same height as containerHeader height
- Settings icon clickable