### PR TITLE
Align send icon 

### DIFF
--- a/src/components/ControlInput.vue
+++ b/src/components/ControlInput.vue
@@ -547,6 +547,7 @@ export default {
     border-radius: 50%;
     margin: 2px 0;
     height: 35px;
+    text-align: center;
     width: 35px;
     cursor: pointer;
     outline: none;


### PR DESCRIPTION
Simple fix that should centre align the send icon. Fix #601 