### PR TITLE
fix `warnOnExit: false` on IE

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -253,7 +253,7 @@ export default {
                     return this.$t('window_unload');
                 }
 
-                return null;
+                return undefined;
             };
         },
         emitBufferPaste(event) {


### PR DESCRIPTION
IE does not honor the null return value here like other browsers do.
see https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload#Notes