### PR TITLE
Fix Safari display problem: too long cursor

### DIFF
--- a/src/components/AppSettings.vue
+++ b/src/components/AppSettings.vue
@@ -384,7 +384,6 @@ export default {
 
 .u-form .kiwi-appsettings-setting-scrollback input {
     box-sizing: border-box;
-    line-height: 30px;
     height: 40px;
     border: 1px solid;
     float: left;

--- a/src/components/NetworkSettings.vue
+++ b/src/components/NetworkSettings.vue
@@ -296,7 +296,6 @@ export default {
     width: 100%;
     height: 40px;
     padding: 0 10px;
-    line-height: 40px;
     box-sizing: border-box;
     border-radius: 1px;
     min-height: none;

--- a/src/res/globalStyle.css
+++ b/src/res/globalStyle.css
@@ -134,7 +134,6 @@ select {
     width: 100%;
     height: 40px;
     padding: 3px 5px;
-    line-height: 40px;
     box-sizing: border-box;
     border-radius: 1px;
     min-height: none;


### PR DESCRIPTION
Been discussed in #690 .
Remove some of the "line-height" which the unnecessary but make the performance on Safari a bit strange (the cursor is much more longer than the characters).
Have already tested on Chrome and Firefox and there is no influence.
But still need test on Edge and IE (probably).