### PR TITLE
Make message. event consistent

### DIFF
--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -977,7 +977,7 @@ const state = new Vue({
                 }
             }
 
-            this.$emit('message.new', bufferMessage, buffer);
+            this.$emit('message.new', { message: bufferMessage, buffer: buffer });
         },
 
         getUser(networkid, nick, usersArr_) {


### PR DESCRIPTION
message.new does not match other message. events

it directly sends the message where as others send events with the message inside