### PR TITLE
Fix autocomplete replacing words when no matches found

### DIFF
--- a/src/components/AutoComplete.vue
+++ b/src/components/AutoComplete.vue
@@ -130,6 +130,10 @@ export default {
         },
     },
     mounted: function mounted() {
+        // We have nothing to show, so lets just close
+        if (!this.filteredAndLimitedItems) {
+            this.cancel();
+        }
         this.tempCurrentItem();
     },
     methods: {


### PR DESCRIPTION
I think this is a better solution than #740 because it stop the borders of the autocomplete box loading

I kept #740 open though because im not sure if the code in that area needs cleaning up