### PR TITLE
FIX: Build lint error + Mobile statebrowser close icon display

### DIFF
--- a/src/components/ContainerHeader.vue
+++ b/src/components/ContainerHeader.vue
@@ -115,6 +115,11 @@
                 {{ $t('connecting') }}
             </div>
             <div class="kiwi-header-name">{{ buffer.getNetwork().name }}</div>
+            <div class="kiwi-header-option kiwi-header-option-leave">
+                <a @click="closeCurrentBuffer">
+                    <i class="fa fa-times" aria-hidden="true"/>
+                </a>
+            </div>
         </template>
 
         <template v-else-if="isQuery()">

--- a/src/components/ContainerHeader.vue
+++ b/src/components/ContainerHeader.vue
@@ -115,11 +115,6 @@
                 {{ $t('connecting') }}
             </div>
             <div class="kiwi-header-name">{{ buffer.getNetwork().name }}</div>
-            <div class="kiwi-header-option kiwi-header-option-leave">
-                <a @click="closeCurrentBuffer">
-                    <i class="fa fa-times" aria-hidden="true"/>
-                </a>
-            </div>
         </template>
 
         <template v-else-if="isQuery()">

--- a/src/components/MessageInfo.vue
+++ b/src/components/MessageInfo.vue
@@ -18,10 +18,10 @@
 
             <div class="kiwi-messageinfo-opbuttons">
                 <input-prompt label="Kick reason:" @submit="onKick">
-                    <a class="u-link kick-user">Kick {{ message.nick }}</a>
+                    <a class="u-link kiwi-messageinfo-kick-user">Kick {{ message.nick }}</a>
                 </input-prompt>
                 <input-prompt label="Ban reason:" @submit="onBan">
-                    <a class="u-link ban-user">Ban {{ message.nick }}</a>
+                    <a class="u-link kiwi-messageinfo-ban-user">Ban {{ message.nick }}</a>
                 </input-prompt>
             </div>
         </div>

--- a/src/components/StateBrowser.vue
+++ b/src/components/StateBrowser.vue
@@ -244,10 +244,10 @@ export default {
     line-height: 45px;
     cursor: pointer;
     font-weight: 500;
-    letter-spacing: 1px;
     transition: all 0.3s;
     border-radius: 0 0 6px 0;
     opacity: 0.8;
+    z-index: 20;
 }
 
 .kiwi-statebrowser-appsettings:hover {
@@ -579,6 +579,7 @@ export default {
         height: 45px;
         width: 45px;
         text-align: center;
+        z-index: 20;
 
         i {
             font-size: 1.2em;
@@ -592,6 +593,10 @@ export default {
 
     .kiwi-statebrowser-usermenu {
         position: relative;
+    }
+
+    .kiwi-statebrowser-usermenu-body .kiwi-close-icon {
+        display: none;
     }
 }
 

--- a/src/components/StateBrowser.vue
+++ b/src/components/StateBrowser.vue
@@ -6,7 +6,6 @@
         </div>
 
         <div class="kiwi-statebrowser-mobile-close" @click="hideStatebrowser">
-            <span>{{ $t('close') }}</span>
             <i class="fa fa-times" aria-hidden="true"/>
         </div>
 
@@ -238,12 +237,11 @@ export default {
     position: absolute;
     top: 0;
     left: 0;
-    width: auto;
-    text-align: left;
-    padding: 0 10px;
+    width: 45px;
+    text-align: center;
     font-size: 1em;
     box-sizing: border-box;
-    line-height: 35px;
+    line-height: 45px;
     cursor: pointer;
     font-weight: 500;
     letter-spacing: 1px;
@@ -261,7 +259,6 @@ export default {
 }
 
 .kiwi-statebrowser-appsettings i {
-    float: right;
     line-height: 35px;
     font-size: 1.2em;
 }
@@ -572,24 +569,18 @@ export default {
     }
 
     .kiwi-statebrowser-mobile-close {
-        width: 100%;
+        position: absolute;
+        top: 0;
+        right: 0;
         color: #fff;
         display: block;
-        padding: 0 10px;
         font-weight: 600;
-        background: #42b992;
-        box-sizing: border-box;
-        margin-bottom: 0;
-        text-transform: uppercase;
         line-height: 45px;
         height: 45px;
-
-        span {
-            float: left;
-        }
+        width: 45px;
+        text-align: center;
 
         i {
-            float: right;
             font-size: 1.2em;
             line-height: 45px;
         }

--- a/static/themes/coffee/theme.css
+++ b/static/themes/coffee/theme.css
@@ -526,12 +526,12 @@
     border-radius: 3px;
 }
 
-.kiwi-messageinfo-actions .u-link.kick-user {
+.kiwi-messageinfo-actions .kiwi-messageinfo-kick-user {
     background: #f6c358;
     color: #fff;
 }
 
-.kiwi-messageinfo-actions .u-link.ban-user {
+.kiwi-messageinfo-actions .kiwi-messageinfo-ban-user {
     background: #fcb46e;
     color: #fff;
 }

--- a/static/themes/dark/theme.css
+++ b/static/themes/dark/theme.css
@@ -652,12 +652,12 @@
     border-radius: 3px;
 }
 
-.kiwi-messageinfo-actions .u-link.kick-user {
+.kiwi-messageinfo-actions .kiwi-messageinfo-kick-user {
     background: #f6c358;
     color: #fff;
 }
 
-.kiwi-messageinfo-actions .u-link.ban-user {
+.kiwi-messageinfo-actions .kiwi-messageinfo-ban-user {
     background: #fcb46e;
     color: #fff;
 }

--- a/static/themes/default/theme.css
+++ b/static/themes/default/theme.css
@@ -696,12 +696,12 @@
     border-radius: 3px;
 }
 
-.kiwi-messageinfo-actions .u-link.kick-user {
+.kiwi-messageinfo-actions .kiwi-messageinfo-kick-user {
     background: #f6c358;
     color: #fff;
 }
 
-.kiwi-messageinfo-actions .u-link.ban-user {
+.kiwi-messageinfo-actions .kiwi-messageinfo-ban-user {
     background: #fcb46e;
     color: #fff;
 }

--- a/static/themes/grayfox/theme.css
+++ b/static/themes/grayfox/theme.css
@@ -528,12 +528,12 @@
     border-radius: 3px;
 }
 
-.kiwi-messageinfo-actions .u-link.kick-user {
+.kiwi-messageinfo-actions .kiwi-messageinfo-kick-user {
     background: #f6c358;
     color: #fff;
 }
 
-.kiwi-messageinfo-actions .u-link.ban-user {
+.kiwi-messageinfo-actions .kiwi-messageinfo-ban-user {
     background: #fcb46e;
     color: #fff;
 }

--- a/static/themes/nightswatch/theme.css
+++ b/static/themes/nightswatch/theme.css
@@ -569,11 +569,11 @@
     border-radius: 3px;
 }
 
-.kiwi-messageinfo-actions .u-link.kick-user {
+.kiwi-messageinfo-actions .kiwi-messageinfo-kick-user {
     color: #f6c358;
 }
 
-.kiwi-messageinfo-actions .u-link.ban-user {
+.kiwi-messageinfo-actions .kiwi-messageinfo-ban-user {
     color: #fcb46e;
 }
 

--- a/static/themes/osprey/theme.css
+++ b/static/themes/osprey/theme.css
@@ -533,12 +533,12 @@
     border-radius: 3px;
 }
 
-.kiwi-messageinfo-actions .u-link.kick-user {
+.kiwi-messageinfo-actions .kiwi-messageinfo-kick-user {
     background: #f6c358;
     color: #fff;
 }
 
-.kiwi-messageinfo-actions .u-link.ban-user {
+.kiwi-messageinfo-actions .kiwi-messageinfo-ban-user {
     background: #fcb46e;
     color: #fff;
 }

--- a/static/themes/radioactive/theme.css
+++ b/static/themes/radioactive/theme.css
@@ -533,11 +533,11 @@
     border-radius: 3px;
 }
 
-.kiwi-messageinfo-actions .u-link.kick-user {
+.kiwi-messageinfo-actions .kiwi-messageinfo-kick-user {
     color: #6fffb0;
 }
 
-.kiwi-messageinfo-actions .u-link.ban-user {
+.kiwi-messageinfo-actions .kiwi-messageinfo-ban-user {
     color: #6fffb0;
 }
 

--- a/static/themes/sky/theme.css
+++ b/static/themes/sky/theme.css
@@ -515,12 +515,12 @@
     border-radius: 3px;
 }
 
-.kiwi-messageinfo-actions .u-link.kick-user {
+.kiwi-messageinfo-actions .kiwi-messageinfo-kick-user{
     background: #f6c358;
     color: #fff;
 }
 
-.kiwi-messageinfo-actions .u-link.ban-user {
+.kiwi-messageinfo-actions .kiwi-messageinfo-ban-user {
     background: #fcb46e;
     color: #fff;
 }


### PR DESCRIPTION
This PR fixes the position of the 'close' icon in the statebrowser. Makes the styling between the KiwiSettings and Close icon consistent too.

I've included a fix for the messageInfo linting error - as I didn't want this build to fail. 

Two birds, one stone - as they say :) 