### PR TITLE
Fix url decoding in Welcome startup

### DIFF
--- a/src/components/startups/Welcome.vue
+++ b/src/components/startups/Welcome.vue
@@ -122,7 +122,7 @@ export default {
 
         this.nick = this.processNickRandomNumber(Misc.queryStringVal('nick') || options.nick || '');
         this.password = options.password || '';
-        this.channel = decodeURI(window.location.hash) || options.channel || '';
+        this.channel = decodeURIComponent(window.location.hash) || options.channel || '';
         this.showChannel = typeof options.showChannel === 'boolean' ?
             options.showChannel :
             true;


### PR DESCRIPTION
decodeURI does not decode %23 (#)
decodeURIComponent does decode correctly and is also used in all the other places

fixes #98 