### PR TITLE
allow building with prerelease engines/npm

### DIFF
--- a/build/check-versions.js
+++ b/build/check-versions.js
@@ -30,7 +30,7 @@ module.exports = function () {
   for (let i = 0; i < versionRequirements.length; i++) {
     const mod = versionRequirements[i]
 
-    if (!semver.satisfies(mod.currentVersion, mod.versionRequirement)) {
+    if (!semver.satisfies(mod.currentVersion, mod.versionRequirement, { includePrerelease: true })) {
       warnings.push(mod.name + ': ' +
         chalk.red(mod.currentVersion) + ' should be ' +
         chalk.green(mod.versionRequirement)

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "lolex": "^1.4.0",
     "mocha": "^3.1.0",
     "phantomjs-prebuilt": "^2.1.3",
+    "semver": "^5.6.0",
     "sinon": "^4.1.4",
     "sinon-chai": "^2.8.0",
     "webpack-dev-middleware": "^1.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6979,6 +6979,11 @@ semver@5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
+semver@^5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
+  integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
+
 semver@~4.3.3:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"


### PR DESCRIPTION
without this:

```console
❯ yarn build
yarn run v1.12.3
$ node build/build.js

To use this template, you must update following to modules:

  npm: 6.5.0-next.0 should be >=3

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```