### PR TITLE
Disconnect message layout improvements FIX: #764 

### DIFF
--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -499,7 +499,6 @@ export default {
     padding: 0.1em 0.5em;
     min-height: 0;
     line-height: normal;
-    margin: 1em 0.5em;
     text-align: left;
 }
 

--- a/src/components/MessageListMessageCompact.vue
+++ b/src/components/MessageListMessageCompact.vue
@@ -176,7 +176,8 @@ export default {
 
 .kiwi-messagelist-message--compact.kiwi-messagelist-message-connection .kiwi-messagelist-body {
     display: inline-block;
-    margin-left: auto;
+    margin: 0;
+    padding: 10px 0;
 }
 
 //Channel topic

--- a/src/components/MessageListMessageModern.vue
+++ b/src/components/MessageListMessageModern.vue
@@ -201,7 +201,6 @@ export default {
 .kiwi-messagelist-message--modern.kiwi-messagelist-message-connection {
     padding: 0;
     box-sizing: border-box;
-    margin: 10px auto;
     width: 100%;
     border: none;
     opacity: 1;

--- a/src/components/NotConnected.vue
+++ b/src/components/NotConnected.vue
@@ -115,14 +115,14 @@ export default {
 .kiwi-notconnected {
     box-sizing: border-box;
     text-align: center;
-    padding: 4% 0;
-    margin: 10px 0 0 0;
+    padding: 2% 0;
+    margin: 0;
     transition: background-color 0.3s;
 }
 
 .kiwi-notconnected-bigicon {
     display: inline-block;
-    margin: 0 0 1em 0;
+    margin: 0 0 0.5em 0;
 }
 
 .kiwi-notconnected-bigicon i {
@@ -142,7 +142,7 @@ export default {
     width: 100%;
     text-align: center;
     font-size: 1.6em;
-    padding-top: 1em;
+    padding-top: 0.5em;
 }
 
 .kiwi-notconnected-button {

--- a/static/themes/default/theme.css
+++ b/static/themes/default/theme.css
@@ -398,7 +398,6 @@
 }
 .kiwi-messagelist-message.kiwi-messagelist-message--unread.kiwi-messagelist-message-connection {
     border-left: none;
-    background: none;
 }
 
 /* When hovering over a users messages */


### PR DESCRIPTION
This PR fixes #764  - making the connected / disconnected messages far more compact. (@ItsOnlyBinary )

- Makes the whole disconnected / connected messages smaller on compact
- Remove the top margin from 'notconnected'
- Tighten up the internal spacing of notconnected