### PR TITLE
Make linkifyChannels() more grabby for prefixes

### DIFF
--- a/src/helpers/TextFormatting.js
+++ b/src/helpers/TextFormatting.js
@@ -128,16 +128,17 @@ export function addEmojis(wordCtx, emojiList, emojiLocation) {
     return word;
 }
 
-const channelMatch = /(^|\s|[@+~&%}]+)([#&][^ .,\007<>\n\r]+?)([:;.,<>\n\r]+)?$/i;
+const channelMatch = /(^|\s)([@+~&%}]*)([#&][^ .,\007<>\n\r]+?)([:;.,<>\n\r]+)?$/i;
 export function linkifyChannels(word) {
     // "@#kiwiirc," = 3 parts. (prefix=@)(channel=#kiwiirc)(suffix=,)
-    return word.replace(channelMatch, (match, mPrefix, mChannel, mSuffix) => {
+    return word.replace(channelMatch, (match, mLead, mPrefix, mChannel, mSuffix) => {
         let chan = _.escape(mChannel.trim());
+        let lead = _.escape(mLead);
         let prefix = _.escape(mPrefix);
         let suffix = _.escape(mSuffix);
 
         let link = `<a class="u-link kiwi-channel" data-channel-name="${chan}">${chan}</a>`;
-        return `${prefix}${link}${suffix}`;
+        return `${lead}${prefix}${link}${suffix}`;
     });
 }
 

--- a/test/unit/specs/TextFormatting.spec.js
+++ b/test/unit/specs/TextFormatting.spec.js
@@ -13,6 +13,8 @@ describe('TextFormatting.js', function() {
             ['#chan[n]el,', '<a class="u-link kiwi-channel" data-channel-name="#chan[n]el">#chan[n]el</a>,'],
             ['@#channel:', '@<a class="u-link kiwi-channel" data-channel-name="#channel">#channel</a>:'],
             ['@&channel,', '@<a class="u-link kiwi-channel" data-channel-name="&amp;channel">&amp;channel</a>,'],
+            ['&@#channel,', '&amp;@<a class="u-link kiwi-channel" data-channel-name="#channel">#channel</a>,'],
+            ['&@&channel,', '&amp;@<a class="u-link kiwi-channel" data-channel-name="&amp;channel">&amp;channel</a>,'],
         ];
 
         tests.forEach((c) => {


### PR DESCRIPTION
Unreal IRCD can have multiple user prefixes on the channel list from whois

This makes the prefixes more grabby so they are not treated as part of the channel names,

added extra tests to ensure it is working correctly

thanks to @Shillos for noticing this issue after pr #765