### PR TITLE
Remove: Settings icon config from state browser channel

### DIFF
--- a/src/components/StateBrowserNetwork.vue
+++ b/src/components/StateBrowserNetwork.vue
@@ -135,14 +135,6 @@
                         </transition>
                     </div>
 
-                    <div
-                        v-if="buffer.isChannel()"
-                        class="kiwi-statebrowser-channel-settings"
-                        @click="showBufferSettings(buffer)"
-                    >
-                        <i class="fa fa-cog" aria-hidden="true"/>
-                    </div>
-
                     <div class="kiwi-statebrowser-channel-leave" @click="closeBuffer(buffer)">
                         <i class="fa fa-times" aria-hidden="true"/>
                     </div>

--- a/src/components/StateBrowserNetwork.vue
+++ b/src/components/StateBrowserNetwork.vue
@@ -278,13 +278,6 @@ export default {
         showNetworkChannels(network) {
             network.showServerBuffer('channels');
         },
-        showBufferSettings(buffer) {
-            if (this.$state.ui.is_narrow) {
-                state.$emit('statebrowser.hide');
-            }
-            this.setActiveBuffer(buffer);
-            this.sidebarState.showBufferSettings();
-        },
         toggleAddChannel() {
             this.channel_add_display = !this.channel_add_display;
             this.channel_filter_display = false;

--- a/src/components/StateBrowserNetwork.vue
+++ b/src/components/StateBrowserNetwork.vue
@@ -445,18 +445,6 @@ export default {
     opacity: 0;
 }
 
-.kiwi-statebrowser-channel-settings {
-    display: block;
-    height: 100%;
-    width: 35px;
-    opacity: 0;
-    text-align: center;
-    font-weight: bold;
-    cursor: pointer;
-    transition: all 0.3s;
-    z-index: 10;
-}
-
 .kiwi-statebrowser-channel-leave {
     float: right;
     opacity: 0;


### PR DESCRIPTION
As discussed with @prawnsalad  :) 

- REMOVE: Remove the settings icons from the statebrowser channel list. It's more of an annoyance than a useful feature.