### PR TITLE
autoConnect + allowNoChannel

### DIFF
--- a/src/components/startups/Welcome.vue
+++ b/src/components/startups/Welcome.vue
@@ -171,11 +171,11 @@ export default {
             options.toggablePassword :
             true;
 
-        if (options.autoConnect && this.nick && this.channel) {
+        this.connectWithoutChannel = !!options.allowNoChannel;
+
+        if (options.autoConnect && this.nick && (this.channel || this.connectWithoutChannel)) {
             this.startUp();
         }
-
-        this.connectWithoutChannel = !!options.allowNoChannel;
 
         this.recaptchaSiteId = options.recaptchaSiteId || '';
     },


### PR DESCRIPTION
If allowNoChannel is set to true, autoConnect must work even if there is no channel specified.