### PR TITLE
Update away status indicator border

### DIFF
--- a/src/components/AwayStatusIndicator.vue
+++ b/src/components/AwayStatusIndicator.vue
@@ -53,6 +53,7 @@ export default {
     height: 7px;
     border-radius: 50%;
     margin: 0 4px 0 0;
+    border: 1px solid #fff;
     transition: background 0.2s;
 }
 

--- a/src/components/MessageListMessageModern.vue
+++ b/src/components/MessageListMessageModern.vue
@@ -195,8 +195,8 @@ export default {
 
 .kiwi-messagelist-awaystatus {
     width: 10px;
-    top: 5px;
-    right: 4px;
+    top: 4px;
+    right: 2px;
     height: 10px;
     position: absolute;
 }

--- a/src/components/StateBrowser.vue
+++ b/src/components/StateBrowser.vue
@@ -300,6 +300,7 @@ export default {
     right: -5px;
     width: 12px;
     height: 12px;
+    border: 1px solid #000;
 }
 
 .kiwi-statebrowser-usermenu-body {

--- a/static/config.json
+++ b/static/config.json
@@ -2,7 +2,7 @@
     "windowTitle": "Kiwi IRC - The web IRC client",
     "startupScreen": "welcome",
     "kiwiServer": "https://localdev.clients.kiwiirc.com/webirc/kiwiirc/",
-    "restricted": true,
+    "restricted": false,
     "theme": "Default",
     "themes": [
         { "name": "Default", "url": "static/themes/default" },
@@ -15,7 +15,7 @@
         { "name": "Sky", "url": "static/themes/sky" }
     ],
     "startupOptions" : {
-        "server": "irc.freenode.net",
+        "server": "irc.snoonet.org",
         "port": 6667,
         "tls": false,
         "direct": false,

--- a/static/config.json
+++ b/static/config.json
@@ -2,7 +2,7 @@
     "windowTitle": "Kiwi IRC - The web IRC client",
     "startupScreen": "welcome",
     "kiwiServer": "https://localdev.clients.kiwiirc.com/webirc/kiwiirc/",
-    "restricted": false,
+    "restricted": true,
     "theme": "Default",
     "themes": [
         { "name": "Default", "url": "static/themes/default" },
@@ -15,7 +15,7 @@
         { "name": "Sky", "url": "static/themes/sky" }
     ],
     "startupOptions" : {
-        "server": "irc.snoonet.org",
+        "server": "irc.freenode.net",
         "port": 6667,
         "tls": false,
         "direct": false,

--- a/static/themes/coffee/theme.css
+++ b/static/themes/coffee/theme.css
@@ -331,7 +331,6 @@
 
 /* Control Input - displayed at bottom of Kiwi ( ControlInput.vue ) */
 .kiwi-controlinput {
-    background: #efefef;
     border-top: 1px solid #e8e8e8;
     color: #272727;
 }
@@ -714,7 +713,7 @@
     color: #fff;
 }
 .kiwi-statebrowser-usermenu .kiwi-awaystatusindicator {
-    border: 1px solid #8e715b;
+    border-color: #8e715b;
 }
 
 .kiwi-aboutbuffer {
@@ -1103,7 +1102,7 @@
 }
 
 .kiwi-awaystatusindicator {
-    border: 1px solid #e1e1e1;
+    border-color: #fff;
     background-color: #42b992;
 }
 

--- a/static/themes/coffee/theme.css
+++ b/static/themes/coffee/theme.css
@@ -706,12 +706,15 @@
 }
 
 .kiwi-statebrowser-usermenu-avatar {
-    background-color: #000;
+    background-color: #7d6859;
     color: #fff;
 }
 .kiwi-statebrowser-usermenu-avatar:hover {
     background-color: #8e715c;
     color: #fff;
+}
+.kiwi-statebrowser-usermenu .kiwi-awaystatusindicator {
+    border: 1px solid #8e715b;
 }
 
 .kiwi-aboutbuffer {

--- a/static/themes/coffee/theme.css
+++ b/static/themes/coffee/theme.css
@@ -53,7 +53,7 @@
 .kiwi-workspace::before {
     background: #42b992;
 }
-.kiwi-workspace::after {
+.kiwi-workspace--disconnected::after {
     background: #bf5155;
 }
 

--- a/static/themes/dark/theme.css
+++ b/static/themes/dark/theme.css
@@ -869,7 +869,7 @@
     color: #dedede;
 }
 .kiwi-statebrowser-usermenu .kiwi-awaystatusindicator {
-    border: 1px solid #22221f;
+    border-color: #22221f;
 }
 
 .kiwi-statebrowser-scrollarea {
@@ -1282,7 +1282,7 @@
 }
 
 .kiwi-awaystatusindicator {
-    border: 1px solid #e1e1e1;
+    border-color: #1e1e1e;
     background-color: #42b992;
 }
 

--- a/static/themes/dark/theme.css
+++ b/static/themes/dark/theme.css
@@ -73,7 +73,7 @@
 .kiwi-workspace::before {
     background: #42b992;
 }
-.kiwi-workspace::after {
+.kiwi-workspace--disconnected::after {
     background: #bf5155;
 }
 

--- a/static/themes/dark/theme.css
+++ b/static/themes/dark/theme.css
@@ -864,10 +864,12 @@
     background-color: #000;
     color: #dedede;
 }
-
 .kiwi-statebrowser-usermenu-avatar:hover {
     background-color: #42b992;
     color: #dedede;
+}
+.kiwi-statebrowser-usermenu .kiwi-awaystatusindicator {
+    border: 1px solid #22221f;
 }
 
 .kiwi-statebrowser-scrollarea {

--- a/static/themes/default/theme.css
+++ b/static/themes/default/theme.css
@@ -726,7 +726,7 @@
     color: #fff;
 }
 .kiwi-statebrowser-usermenu .kiwi-awaystatusindicator {
-    border: 1px solid #22221f;
+    border-color: #22221f;
 }
 
 /* If the user clicks on their avatar we 'open' the settings */

--- a/static/themes/default/theme.css
+++ b/static/themes/default/theme.css
@@ -55,7 +55,7 @@
 .kiwi-workspace::before {
     background: #42b992;
 }
-.kiwi-workspace::after {
+.kiwi-workspace--disconnected::after {
     background: #bf5155;
 }
 

--- a/static/themes/default/theme.css
+++ b/static/themes/default/theme.css
@@ -1048,7 +1048,7 @@
 }
 
 .kiwi-awaystatusindicator {
-    border: 1px solid #e1e1e1;
+    border: 1px solid #fff;
     background-color: #42b992;
 }
 

--- a/static/themes/default/theme.css
+++ b/static/themes/default/theme.css
@@ -725,6 +725,9 @@
     background-color: #42b992;
     color: #fff;
 }
+.kiwi-statebrowser-usermenu .kiwi-awaystatusindicator {
+    border: 1px solid #22221f;
+}
 
 /* If the user clicks on their avatar we 'open' the settings */
 .kiwi-statebrowser-usermenu--open {

--- a/static/themes/grayfox/theme.css
+++ b/static/themes/grayfox/theme.css
@@ -1075,7 +1075,7 @@
 }
 
 .kiwi-awaystatusindicator {
-    border: 1px solid #e1e1e1;
+    border: 1px solid #fff;
     background-color: #42b992;
 }
 

--- a/static/themes/grayfox/theme.css
+++ b/static/themes/grayfox/theme.css
@@ -332,7 +332,6 @@
 
 /* Control Input - displayed at bottom of Kiwi ( ControlInput.vue ) */
 .kiwi-controlinput {
-    background: #efefef;
     border-top: 1px solid #e8e8e8;
     color: #272727;
 }
@@ -736,7 +735,7 @@
     color: #fff;
 }
 .kiwi-statebrowser-usermenu .kiwi-awaystatusindicator {
-    border: 1px solid #414957;
+    border-color: #414957;
 }
 
 /* If the user clicks on their avatar we 'open' the settings */

--- a/static/themes/grayfox/theme.css
+++ b/static/themes/grayfox/theme.css
@@ -52,7 +52,7 @@
 .kiwi-workspace::before {
     background: #42b992;
 }
-.kiwi-workspace::after {
+.kiwi-workspace--disconnected::after {
     background: #bf5155;
 }
 

--- a/static/themes/grayfox/theme.css
+++ b/static/themes/grayfox/theme.css
@@ -735,6 +735,9 @@
     background-color: #687282;
     color: #fff;
 }
+.kiwi-statebrowser-usermenu .kiwi-awaystatusindicator {
+    border: 1px solid #414957;
+}
 
 /* If the user clicks on their avatar we 'open' the settings */
 .kiwi-statebrowser-usermenu--open {

--- a/static/themes/nightswatch/theme.css
+++ b/static/themes/nightswatch/theme.css
@@ -70,7 +70,7 @@
 .kiwi-workspace::before {
     background: #42b992;
 }
-.kiwi-workspace::after {
+.kiwi-workspace--disconnected::after {
     background: #bf5155;
 }
 

--- a/static/themes/nightswatch/theme.css
+++ b/static/themes/nightswatch/theme.css
@@ -789,12 +789,15 @@
 }
 
 .kiwi-statebrowser-usermenu-avatar {
-    background-color: #999;
+    background-color: #000;
     color: #d8d8d8;
 }
 .kiwi-statebrowser-usermenu-avatar:hover {
     background-color: #ddd;
     color: #fff;
+}
+.kiwi-statebrowser-usermenu .kiwi-awaystatusindicator {
+    border: 1px solid #000;
 }
 
 /* If the user clicks on their avatar we 'open' the settings */

--- a/static/themes/nightswatch/theme.css
+++ b/static/themes/nightswatch/theme.css
@@ -797,7 +797,7 @@
     color: #fff;
 }
 .kiwi-statebrowser-usermenu .kiwi-awaystatusindicator {
-    border: 1px solid #000;
+    border-color: #000;
 }
 
 /* If the user clicks on their avatar we 'open' the settings */
@@ -1196,8 +1196,8 @@
 }
 
 .kiwi-awaystatusindicator {
-    border: 1px solid #e1e1e1;
-    background-color: #135f46;
+    border-color: #000;
+    background-color: #3bba91;
 }
 
 .kiwi-awaystatusindicator--away {

--- a/static/themes/osprey/theme.css
+++ b/static/themes/osprey/theme.css
@@ -738,7 +738,7 @@
     color: #fff;
 }
 .kiwi-statebrowser-usermenu .kiwi-awaystatusindicator {
-    border: 1px solid #212d3b;
+    border-color: #212d3b;
 }
 
 /* If the user clicks on their avatar we 'open' the settings */

--- a/static/themes/osprey/theme.css
+++ b/static/themes/osprey/theme.css
@@ -62,7 +62,7 @@
 .kiwi-workspace::before {
     background: #42b992;
 }
-.kiwi-workspace::after {
+.kiwi-workspace--disconnected::after {
     background: #bf5155;
 }
 

--- a/static/themes/osprey/theme.css
+++ b/static/themes/osprey/theme.css
@@ -737,6 +737,9 @@
     background-color: #4e5c6b;
     color: #fff;
 }
+.kiwi-statebrowser-usermenu .kiwi-awaystatusindicator {
+    border: 1px solid #212d3b;
+}
 
 /* If the user clicks on their avatar we 'open' the settings */
 .kiwi-statebrowser-usermenu--open {

--- a/static/themes/osprey/theme.css
+++ b/static/themes/osprey/theme.css
@@ -340,7 +340,6 @@
 
 /* Control Input - displayed at bottom of Kiwi ( ControlInput.vue ) */
 .kiwi-controlinput {
-    background: #efefef;
     border-top: 1px solid #e8e8e8;
     color: #272727;
 }
@@ -1081,7 +1080,7 @@
 }
 
 .kiwi-awaystatusindicator {
-    border: 1px solid #e1e1e1;
+    border: 1px solid #fff;
     background-color: #42b992;
 }
 

--- a/static/themes/radioactive/theme.css
+++ b/static/themes/radioactive/theme.css
@@ -738,6 +738,9 @@
     background-color: #5dd895;
     color: #fff;
 }
+.kiwi-statebrowser-usermenu .kiwi-awaystatusindicator {
+    border: 1px solid #1a2f24;
+}
 
 /* If the user clicks on their avatar we 'open' the settings */
 .kiwi-statebrowser-usermenu--open {

--- a/static/themes/radioactive/theme.css
+++ b/static/themes/radioactive/theme.css
@@ -739,7 +739,7 @@
     color: #fff;
 }
 .kiwi-statebrowser-usermenu .kiwi-awaystatusindicator {
-    border: 1px solid #1a2f24;
+    border-color: #1a2f24;
 }
 
 /* If the user clicks on their avatar we 'open' the settings */
@@ -1124,7 +1124,7 @@
 }
 
 .kiwi-awaystatusindicator {
-    border: 1px solid #e1e1e1;
+    border: #1a2f24;
     background-color: #5dd895;
 }
 

--- a/static/themes/radioactive/theme.css
+++ b/static/themes/radioactive/theme.css
@@ -50,7 +50,7 @@
 .kiwi-workspace::before {
     background: #42b992;
 }
-.kiwi-workspace::after {
+.kiwi-workspace--disconnected::after {
     background: #bf5155;
 }
 

--- a/static/themes/sky/theme.css
+++ b/static/themes/sky/theme.css
@@ -719,7 +719,7 @@
     color: #fff;
 }
 .kiwi-statebrowser-usermenu .kiwi-awaystatusindicator {
-    border: 1px solid #94e5f7;
+    border-color: #94e5f7;
 }
 
 /* If the user clicks on their avatar we 'open' the settings */

--- a/static/themes/sky/theme.css
+++ b/static/themes/sky/theme.css
@@ -718,6 +718,9 @@
     background-color: #69bdd0;
     color: #fff;
 }
+.kiwi-statebrowser-usermenu .kiwi-awaystatusindicator {
+    border: 1px solid #94e5f7;
+}
 
 /* If the user clicks on their avatar we 'open' the settings */
 .kiwi-statebrowser-usermenu--open {

--- a/static/themes/sky/theme.css
+++ b/static/themes/sky/theme.css
@@ -326,7 +326,6 @@
 
 /* Control Input - displayed at bottom of Kiwi ( ControlInput.vue ) */
 .kiwi-controlinput {
-    background: #efefef;
     border-top: 1px solid #e8e8e8;
     color: #272727;
 }
@@ -719,7 +718,7 @@
     color: #fff;
 }
 .kiwi-statebrowser-usermenu .kiwi-awaystatusindicator {
-    border-color: #94e5f7;
+    border-color: #6cc3d8;
 }
 
 /* If the user clicks on their avatar we 'open' the settings */
@@ -1060,7 +1059,7 @@
 }
 
 .kiwi-awaystatusindicator {
-    border: 1px solid #e1e1e1;
+    border: 1px solid #fff;
     background-color: #42b992;
 }
 

--- a/static/themes/sky/theme.css
+++ b/static/themes/sky/theme.css
@@ -52,7 +52,7 @@
 .kiwi-workspace::before {
     background: #42b992;
 }
-.kiwi-workspace::after {
+.kiwi-workspace--disconnected::after {
     background: #bf5155;
 }
 


### PR DESCRIPTION
The away status indicator in the statebrowser now has a border colour, the same colour as the statebrowser.

I've also made the css targeting the Kiwi-workspace::after more specific, as currently it targets both connected/disconnected states, and we don't want that