### PR TITLE
HOTFIX: Solve self user z-index issue on mobile devices.

### DIFF
--- a/src/components/ControlInput.vue
+++ b/src/components/ControlInput.vue
@@ -685,12 +685,6 @@ export default {
     transition: all 0.4s;
 }
 
-@media screen and (max-width: 769px) {
-    .kiwi-controlinput {
-        z-index: 0;
-    }
-}
-
 @media screen and (max-width: 500px) {
     .kiwi-controlinput-user-nick {
         display: none;


### PR DESCRIPTION
This is a quick fix for master, myself and @prawnsalad will discuss and implement a better way of doing this over the next day.

- REMOVE: Media Query in controlInput that added z-index:0 when in mobile view