### PR TITLE
Add output to /mode #chan +b. fixes #761. also misc bug fixes.

### DIFF
--- a/src/components/AwayStatusIndicator.vue
+++ b/src/components/AwayStatusIndicator.vue
@@ -1,7 +1,7 @@
 <template>
     <span
         v-if="shouldShowStatus"
-        :class="{ 'kiwi-awaystatusindicator--away': user&&user.isAway(),
+        :class="{ 'kiwi-awaystatusindicator--away': user && user.isAway(),
                   'kiwi-awaystatusindicator--self': isUserSelf }"
         class="kiwi-awaystatusindicator"
         @click="toggleSelfAway()"

--- a/src/components/AwayStatusIndicator.vue
+++ b/src/components/AwayStatusIndicator.vue
@@ -1,7 +1,7 @@
 <template>
     <span
         v-if="shouldShowStatus"
-        :class="{ 'kiwi-awaystatusindicator--away': user.isAway(),
+        :class="{ 'kiwi-awaystatusindicator--away': user&&user.isAway(),
                   'kiwi-awaystatusindicator--self': isUserSelf }"
         class="kiwi-awaystatusindicator"
         @click="toggleSelfAway()"

--- a/src/libs/InputHandler.js
+++ b/src/libs/InputHandler.js
@@ -708,6 +708,11 @@ inputCommands.mode = function inputCommandMode(event, command, line) {
         // If we're asking for a ban list, show the response in the active channel
         if (parts[0] === '+b' && parts[1] == null) {
             buffer.flags.requested_banlist = true;
+            // An IRCd may fuck up and simply not reply to a MODE command. Give a few seconds
+            // for it to reply and if not, ignore our request was sent
+            setTimeout(() => {
+                buffer.flags.requested_banlist = false;
+            }, 4000);
         }
 
         network.ircClient.mode(target, parts[0], parts[1]);

--- a/src/libs/InputHandler.js
+++ b/src/libs/InputHandler.js
@@ -706,7 +706,7 @@ inputCommands.mode = function inputCommandMode(event, command, line) {
         // parts[1] = optional mode arguments
 
         // If we're asking for a ban list, show the response in the active channel
-        if (parts[0] === '+b' && parts[1] == null) {
+        if (parts[0] === '+b' && !parts[1]) {
             buffer.flags.requested_banlist = true;
             // An IRCd may fuck up and simply not reply to a MODE command. Give a few seconds
             // for it to reply and if not, ignore our request was sent

--- a/src/libs/InputHandler.js
+++ b/src/libs/InputHandler.js
@@ -704,6 +704,12 @@ inputCommands.mode = function inputCommandMode(event, command, line) {
     if (parts[0]) {
         // parts[0] = the mode(s)
         // parts[1] = optional mode arguments
+
+        // If we're asking for a ban list, show the response in the active channel
+        if (parts[0] === '+b' && parts[1] == null) {
+            buffer.flags.requested_banlist = true;
+        }
+
         network.ircClient.mode(target, parts[0], parts[1]);
     } else {
         // No modes specified will request the modes for the target

--- a/src/libs/InputHandler.js
+++ b/src/libs/InputHandler.js
@@ -145,8 +145,7 @@ function handleMessage(type, event, command, line) {
 
     let bufferName = line.substr(0, spaceIdx);
     let message = line.substr(spaceIdx + 1);
-
-    let buffer = this.state.getOrAddBufferByName(network.id, bufferName);
+    let buffer = bufferName.length && this.state.getOrAddBufferByName(network.id, bufferName);
     if (buffer) {
         let textFormatType = 'privmsg';
         if (type === 'action') {

--- a/src/libs/IrcClient.js
+++ b/src/libs/IrcClient.js
@@ -987,7 +987,7 @@ function clientMiddleware(state, network) {
         if (command === 'banlist') {
             let buffer = state.getBufferByName(networkid, event.channel);
             if (buffer && buffer.flags.requested_banlist) {
-                if (event.bans == null || event.bans.length === 0) {
+                if (!event.bans || event.bans.length === 0) {
                     state.addMessage(buffer, {
                         time: event.time || Date.now(),
                         nick: '',

--- a/src/libs/IrcClient.js
+++ b/src/libs/IrcClient.js
@@ -984,6 +984,30 @@ function clientMiddleware(state, network) {
             }
         }
 
+        if (command === 'banlist') {
+            let buffer = state.getBufferByName(networkid, event.channel);
+            if (buffer != null && buffer.flags.requested_banlist) {
+                if (event.bans == null || event.bans.length === 0) {
+                    state.addMessage(buffer, {
+                        time: event.time || Date.now(),
+                        nick: '',
+                        message: TextFormatting.t('bans_nobody'),
+                        type: 'banlist',
+                    });
+                } else {
+                    _.each(event.bans, (ban) => {
+                        state.addMessage(buffer, {
+                            time: event.time || Date.now(),
+                            nick: '',
+                            message: `${ban.banned} ${TextFormatting.t('bans_by')} ${ban.banned_by} on ${(new Date(ban.banned_at * 1000)).toDateString()}`,
+                            type: 'banlist',
+                        });
+                    });
+                }
+                buffer.flags.requested_banlist = false;
+            }
+        }
+
         if (command === 'topic') {
             let buffer = state.getOrAddBufferByName(networkid, event.channel);
             buffer.topic = event.topic || '';

--- a/src/libs/IrcClient.js
+++ b/src/libs/IrcClient.js
@@ -986,7 +986,7 @@ function clientMiddleware(state, network) {
 
         if (command === 'banlist') {
             let buffer = state.getBufferByName(networkid, event.channel);
-            if (buffer != null && buffer.flags.requested_banlist) {
+            if (buffer && buffer.flags.requested_banlist) {
                 if (event.bans == null || event.bans.length === 0) {
                     state.addMessage(buffer, {
                         time: event.time || Date.now(),
@@ -995,13 +995,17 @@ function clientMiddleware(state, network) {
                         type: 'banlist',
                     });
                 } else {
+                    let banText = '';
                     _.each(event.bans, (ban) => {
-                        state.addMessage(buffer, {
-                            time: event.time || Date.now(),
-                            nick: '',
-                            message: `${ban.banned} ${TextFormatting.t('bans_by')} ${ban.banned_by} on ${(new Date(ban.banned_at * 1000)).toDateString()}`,
-                            type: 'banlist',
-                        });
+                        let dateStr = (new Date(ban.banned_at * 1000)).toDateString();
+                        banText += `+b ${ban.banned} [by ${ban.banned_by}, ${dateStr}]\n`;
+                    });
+
+                    state.addMessage(buffer, {
+                        time: event.time || Date.now(),
+                        nick: '*',
+                        message: banText,
+                        type: 'banlist',
                     });
                 }
                 buffer.flags.requested_banlist = false;

--- a/src/libs/state/BufferState.js
+++ b/src/libs/state/BufferState.js
@@ -29,6 +29,7 @@ export default class BufferState {
             channel_badkey: false,
             chathistory_available: true,
             requested_modes: false,
+            requested_banlist: false,
         };
         this.settings = { };
         this.last_read = 0;

--- a/src/res/configTemplates.js
+++ b/src/res/configTemplates.js
@@ -93,6 +93,7 @@ export const configTemplates = {
 /voice /quote mode $channel +v $1+
 /devoice /quote mode $channel -v $1+
 /k /kick $channel $1+
+/bans /mode $channel +b
 /ban /quote mode $channel +b $1+
 /unban /quote mode $channel -b $1+
 


### PR DESCRIPTION
bc77dfe Fixes a bug where `/notice` or `/action` without arguments  would create an empty buffer.

3cd0343 Stop errors being spammed to console when opening a buffer to a user that the client doesn't know about.