### PR TITLE
Remove user icon from statebrowser

### DIFF
--- a/static/themes/common/base.css
+++ b/static/themes/common/base.css
@@ -561,10 +561,6 @@
 }
 
 /* Icons in the Channel List */
-.kiwi-statebrowser-channel:not([data-name^="#"])::before {
-    content: '\f007';
-}
-
 .kiwi-statebrowser-channel[data-name^="*"]::before {
     content: '\f006';
 }


### PR DESCRIPTION
Remove user icon from the statebrowser, removing it from the base theme.