### PR TITLE
HOTFIX: Remove height 100% from app.vue line 473.

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -424,7 +424,7 @@ body {
     left: 0;
     width: 200px;
     bottom: 0;
-    transition: all 0.1s;
+    transition: left 0.145s, margin-left 0.145s;
     z-index: 1;
 }
 

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -467,11 +467,5 @@ body {
         left: 75%;
         width: 80%;
     }
-
-    .kiwi-wrap--statebrowser-drawopen .kiwi-workspace::after {
-        width: 100%;
-        opacity: 1;
-        z-index: 10;
-    }
 }
 </style>

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -465,7 +465,8 @@ body {
 
     .kiwi-wrap--statebrowser-drawopen .kiwi-workspace {
         left: 75%;
-        transition: all 0.2s;
+        transition: left 0.1s;
+        transition-delay: 0s;
     }
 }
 </style>

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -470,7 +470,6 @@ body {
 
     .kiwi-wrap--statebrowser-drawopen .kiwi-workspace::after {
         width: 100%;
-        height: 100%;
         opacity: 1;
         z-index: 10;
     }

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -424,7 +424,7 @@ body {
     left: 0;
     width: 200px;
     bottom: 0;
-    transition: left 0.2s;
+    transition: all 0.1s;
     z-index: 1;
 }
 
@@ -465,7 +465,7 @@ body {
 
     .kiwi-wrap--statebrowser-drawopen .kiwi-workspace {
         left: 75%;
-        width: 80%;
+        transition: all 0.2s;
     }
 }
 </style>

--- a/src/components/Container.vue
+++ b/src/components/Container.vue
@@ -269,7 +269,7 @@ export default {
     line-height: 2em;
     box-sizing: border-box;
     top: 10px;
-    z-index: 4;
+    z-index: 100;
     white-space: nowrap;
     left: 14px;
     width: 37px;
@@ -297,7 +297,6 @@ export default {
 /* When the Statebrowser is visible, apply new styles to the messagecount */
 .kiwi-wrap--statebrowser-drawopen .kiwi-container-toggledraw-statebrowser-messagecount {
     left: -19px;
-    z-index: 100;
 }
 
 .kiwi-wrap--statebrowser-drawopen .kiwi-container-toggledraw-statebrowser-messagecount::after {
@@ -332,6 +331,21 @@ export default {
     padding: 0 14px;
 }
 
+.kiwi-wrap .kiwi-container::after {
+    content: '';
+    position: absolute;
+    left: auto;
+    height: 120%;
+    background-color: rgba(0, 0, 0, 0.4);
+    top: 0;
+    opacity: 0;
+    z-index: 99;
+    width: 0%;
+    right: -100%;
+    transition: opacity 0.1s;
+    transition-delay: opacity 0.1s;
+}
+
 @media screen and (max-width: 1500px) {
     .kiwi-container--sidebar-open .kiwi-sidebar {
         max-width: 350px;
@@ -345,6 +359,13 @@ export default {
 
     .kiwi-wrap--statebrowser-drawopen .kiwi-container-statebrowser-messagecount-close {
         display: block;
+    }
+
+    .kiwi-wrap--statebrowser-drawopen .kiwi-container::after {
+        top: 0;
+        opacity: 1;
+        width: 100%;
+        right: 0%;
     }
 
     .kiwi-header {

--- a/src/components/ControlInput.vue
+++ b/src/components/ControlInput.vue
@@ -732,6 +732,10 @@ export default {
     .kiwi-controlinput-selfuser--open .kiwi-controlinput-selfuser {
         width: 100%;
     }
+
+    .kiwi-wrap--statebrowser-drawopen .kiwi-controlinput {
+        z-index: 0;
+    }
 }
 
 </style>

--- a/src/components/StateBrowser.vue
+++ b/src/components/StateBrowser.vue
@@ -583,6 +583,7 @@ export default {
         width: 75%;
         left: 0;
         z-index: 100;
+        overflow: visible;
     }
 
     .kiwi-header {
@@ -613,6 +614,18 @@ export default {
 
     .kiwi-statebrowser-usermenu-body .kiwi-close-icon {
         display: none;
+    }
+
+    .kiwi-wrap--statebrowser-drawopen .kiwi-statebrowser::after {
+        content: '';
+        position: absolute;
+        left: auto;
+        height: 100%;
+        background-color: rgba(0, 0, 0, 0.4);
+        top: 0;
+        z-index: 1;
+        width: 100%;
+        right: -100%;
     }
 }
 

--- a/src/components/StateBrowser.vue
+++ b/src/components/StateBrowser.vue
@@ -572,6 +572,19 @@ export default {
     opacity: 1;
 }
 
+.kiwi-wrap .kiwi-statebrowser::after {
+    content: '';
+    position: absolute;
+    left: auto;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.4);
+    top: 0;
+    opacity: 0;
+    z-index: 1;
+    width: 0%;
+    right: -100%;
+}
+
 @media screen and (max-width: 769px) {
     .kiwi-statebrowser {
         left: -100%;
@@ -617,15 +630,10 @@ export default {
     }
 
     .kiwi-wrap--statebrowser-drawopen .kiwi-statebrowser::after {
-        content: '';
-        position: absolute;
-        left: auto;
-        height: 100%;
-        background-color: rgba(0, 0, 0, 0.4);
-        top: 0;
-        z-index: 1;
+        opacity: 1;
         width: 100%;
         right: -100%;
+        transition: width 0.2s, opacity 0.2s;
     }
 }
 

--- a/src/components/StateBrowser.vue
+++ b/src/components/StateBrowser.vue
@@ -233,7 +233,7 @@ export default {
     width: 220px;
     text-align: center;
     overflow: hidden;
-    transition: all 0.2s;
+    transition: all 0.145s;
 }
 
 .kiwi-statebrowser h1 {
@@ -577,7 +577,7 @@ export default {
         width: 75%;
         left: 0;
         z-index: 100;
-        transition: all 0.1s;
+        transition: left 0.07s, width 0.1s;
     }
 
     .kiwi-header {

--- a/src/components/StateBrowser.vue
+++ b/src/components/StateBrowser.vue
@@ -233,7 +233,7 @@ export default {
     width: 220px;
     text-align: center;
     overflow: hidden;
-    transition: all 0.145s;
+    transition: left 0.145s, margin-left 0.145s;
 }
 
 .kiwi-statebrowser h1 {

--- a/src/components/StateBrowser.vue
+++ b/src/components/StateBrowser.vue
@@ -234,12 +234,6 @@ export default {
     text-align: center;
     overflow: hidden;
     transition: all 0.2s;
-    transition-delay: 0.05s;
-}
-
-.kiwi-statebrowser.kiwi-wrap--statebrowser-drawopen {
-    transition: all 0.2s;
-    transition-delay: 0.05s;
 }
 
 .kiwi-statebrowser h1 {
@@ -572,19 +566,6 @@ export default {
     opacity: 1;
 }
 
-.kiwi-wrap .kiwi-statebrowser::after {
-    content: '';
-    position: absolute;
-    left: auto;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.4);
-    top: 0;
-    opacity: 0;
-    z-index: 1;
-    width: 0%;
-    right: -100%;
-}
-
 @media screen and (max-width: 769px) {
     .kiwi-statebrowser {
         left: -100%;
@@ -596,7 +577,7 @@ export default {
         width: 75%;
         left: 0;
         z-index: 100;
-        overflow: visible;
+        transition: all 0.1s;
     }
 
     .kiwi-header {

--- a/src/components/startups/Welcome.vue
+++ b/src/components/startups/Welcome.vue
@@ -418,6 +418,7 @@ export default {
     margin-top: -0.5em;
     left: 50%;
     margin-left: -40px;
+    color: black;
 }
 
 /** Smaller screen... **/
@@ -448,7 +449,6 @@ export default {
         left: 48%;
         top: 50%;
         margin-top: -50px;
-        color: #fff;
     }
 }
 


### PR DESCRIPTION
The bug: When not connected to a channel, in mobile view, the 'disconnected' line at the top is being given a height of 100%. This should not be happening. 

 This bug was previously solved but must have been remerged in recently by some app.vue work.