### PR TITLE
Dark theme update, increase nick brightness

### DIFF
--- a/static/themes/dark/theme.css
+++ b/static/themes/dark/theme.css
@@ -33,6 +33,10 @@
     --comp-border: #484848;
 }
 
+.kiwi-wrap {
+    --kiwi-nick-brightness: 60;
+}
+
 .kiwi-header {
     border-bottom-color: #000;
 }


### PR DESCRIPTION
The default setting of 40 is unreadable on a black background in my opinion.