### PR TITLE
Makes forgetState() async

### DIFF
--- a/src/libs/StatePersistence.js
+++ b/src/libs/StatePersistence.js
@@ -85,8 +85,8 @@ export default class StatePersistence {
         this.isPersisting = true;
     }
 
-    forgetState() {
+    async forgetState() {
         this.state.resetState();
-        this.storage.set(this.storageKey, null);
+        await this.storage.set(this.storageKey, null);
     }
 }


### PR DESCRIPTION
This fixes a bug in the "log out" in the mobile app where sometimes we were navigating back to the beginning before the state was cleaned.

Also, it makes sense to make this app async because the underlying function (`storage.set`) is already async and the sibling function `loadStateIfExists()` is async.