### PR TITLE
Dark, Elite, Nightswatch and Radioactive theme style additions/corrections.

### DIFF
--- a/static/themes/dark/theme.css
+++ b/static/themes/dark/theme.css
@@ -67,6 +67,11 @@
     border-right: 0;
 }
 
+.u-form select {
+    background-color: var(--brand-primary);
+    color: #000000;
+}
+
 button.u-button.u-button-primary.u-submit.kiwi-welcome-znc-start,
 .kiwi-statebrowser-channel-label {
     color: var(--brand-default-fg);
@@ -165,6 +170,11 @@ button.u-button.u-button-primary.u-submit.kiwi-welcome-znc-start,
 .kiwi-sidebar-options,
 .kiwi-aboutbuffer h4 {
     color: #fff;
+}
+
+.kiwi-messagelist .kiwi-messagelist-body a,
+.kiwi-messagelist .kiwi-messagelist-body a:hover {
+    color: var(--brand-primary);
 }
 
 /* IRC Text Colours */

--- a/static/themes/elite/theme.css
+++ b/static/themes/elite/theme.css
@@ -110,6 +110,11 @@
     background-color: #151a1d;
 }
 
+.u-form select {
+    background-color: #26323a;
+}
+
+
 .kiwi-messagelist {
     background: #3b4850;
     color: var(--brand-primary);

--- a/static/themes/nightswatch/theme.css
+++ b/static/themes/nightswatch/theme.css
@@ -201,6 +201,10 @@
     background-color: #f1f1f1;
 }
 
+.u-form select {
+    background-color: var(--brand-primary);
+}
+
 .u-link {
     color: var(--brand-default-fg);
 }

--- a/static/themes/radioactive/theme.css
+++ b/static/themes/radioactive/theme.css
@@ -145,6 +145,10 @@
 }
 
 
+.u-form select {
+    background-color: #183123;
+}
+
 /*buttons */
 .u-button {
     color: #2c3e50;


### PR DESCRIPTION
For the General Appsettings component the theme drop down selector needed background adjustments.

Before it appeared like this for Dark theme.

![image](https://user-images.githubusercontent.com/24723440/56448857-3c8b6a00-62d0-11e9-8018-7338df37a491.png)

After corrections now appears as this.

![image](https://user-images.githubusercontent.com/24723440/56448871-5036d080-62d0-11e9-99ea-7c8d732f9feb.png)

Similar adjustments was needed for Elite, Nightswatch, and Radioactive to match the appropriate color.

Reading hyperlinks for dark theme was difficult with dark blue and purple on the dark background.
Hyperlinks have been adjusted to use themes primary brand color.

Before:

![image](https://user-images.githubusercontent.com/24723440/56448912-d5ba8080-62d0-11e9-9712-0d333a7098ea.png)

After:

![image](https://user-images.githubusercontent.com/24723440/56448916-db17cb00-62d0-11e9-9c40-f45ccfc41fda.png)

