### PR TITLE
Colour accessibility

### DIFF
--- a/static/themes/coffee/theme.css
+++ b/static/themes/coffee/theme.css
@@ -107,6 +107,9 @@
     color: #fff;
 }
 
+.kiwi-statebrowser-network-status {
+    background: rgba(0, 0, 0, 0.24);
+}
 
 /* IRC Text Colours */
 .irc-fg-colour-white { color: #fff; }

--- a/static/themes/dark/theme.css
+++ b/static/themes/dark/theme.css
@@ -6,7 +6,7 @@
     --brand-midtone: #f1f1f1;
     --brand-darktone: #969696;
     --brand-default-bg: #1e1e1e;
-    --brand-default-fg: #e2e2e2;
+    --brand-default-fg: #fff;
     --brand-notice: #f6c358;
     --brand-warning: #fcb46e;
     --brand-error: #bf5155;

--- a/static/themes/dark/theme.css
+++ b/static/themes/dark/theme.css
@@ -177,6 +177,10 @@ button.u-button.u-button-primary.u-submit.kiwi-welcome-znc-start,
     color: var(--brand-primary);
 }
 
+.kiwi-header-server-connection .u-button {
+    color: #fff;
+}
+
 /* IRC Text Colours */
 .irc-fg-colour-white { color: #fff; }
 .irc-fg-colour-black { color: #000; }

--- a/static/themes/grayfox/theme.css
+++ b/static/themes/grayfox/theme.css
@@ -107,6 +107,10 @@
     background: #f1f1f1;
 }
 
+.kiwi-statebrowser-network-status .u-link {
+    color: var(--brand-default-bg);
+}
+
 /* IRC Text Colours */
 .irc-fg-colour-white { color: #fff; }
 .irc-fg-colour-black { color: #000; }

--- a/static/themes/grayfox/theme.css
+++ b/static/themes/grayfox/theme.css
@@ -115,6 +115,17 @@
     color: #414957;
 }
 
+.kiwi-container-toggledraw-statebrowser-messagecount {
+    background-color: #626975;
+}
+.kiwi-wrap--statebrowser-drawopen .kiwi-container-toggledraw-statebrowser-messagecount::after {
+    border-left-color: #626975;
+}
+.kiwi-container-toggledraw-statebrowser-messagecount::after {
+    border-right-color: #626975;
+}
+
+
 /* IRC Text Colours */
 .irc-fg-colour-white { color: #fff; }
 .irc-fg-colour-black { color: #000; }

--- a/static/themes/grayfox/theme.css
+++ b/static/themes/grayfox/theme.css
@@ -2,7 +2,7 @@
 
 :root {
     /* Primary Variables */
-    --brand-primary: #747c88;
+    --brand-primary: #454e5a;
     --brand-primary-hover: #9098a2;
     --brand-midtone: #f1f1f1;
     --brand-darktone: #969696;

--- a/static/themes/grayfox/theme.css
+++ b/static/themes/grayfox/theme.css
@@ -111,6 +111,10 @@
     color: var(--brand-default-bg);
 }
 
+.kiwi-advanced-setting--modified .u-link {
+    color: #414957;
+}
+
 /* IRC Text Colours */
 .irc-fg-colour-white { color: #fff; }
 .irc-fg-colour-black { color: #000; }

--- a/static/themes/nightswatch/theme.css
+++ b/static/themes/nightswatch/theme.css
@@ -317,6 +317,7 @@ button.u-button.u-button-primary.u-submit.kiwi-welcome-znc-start,
     color: #fdfdfd;
 }
 
+.kiwi-sidebar-options,
 .kiwi-messagelist-message--compact .kiwi-messagelist-time {
     color: #fff;
 }

--- a/static/themes/osprey/theme.css
+++ b/static/themes/osprey/theme.css
@@ -89,6 +89,10 @@
     background-color: #2c3843;
 }
 
+.kiwi-statebrowser-network .kiwi-statebrowser-network-header {
+    background-color: #4e5c6b;
+}
+
 /* IRC Text Colours */
 .irc-fg-colour-white { color: #fff; }
 .irc-fg-colour-black { color: #000; }

--- a/static/themes/osprey/theme.css
+++ b/static/themes/osprey/theme.css
@@ -84,6 +84,11 @@
     color: var(--brand-default-bg);
 }
 
+.kiwi-statebrowser-channel-settings,
+.kiwi-statebrowser-channel-leave {
+    background-color: #2c3843;
+}
+
 /* IRC Text Colours */
 .irc-fg-colour-white { color: #fff; }
 .irc-fg-colour-black { color: #000; }

--- a/static/themes/sky/theme.css
+++ b/static/themes/sky/theme.css
@@ -2,7 +2,7 @@
 
 :root {
     /* Primary Variables */
-    --brand-primary: #78c9dc;
+    --brand-primary: #0f7890;
     --brand-primary-hover: #8fd9ea;
     --brand-midtone: #f1f1f1;
     --brand-darktone: #969696;
@@ -26,7 +26,7 @@
 
     /* StateBrowser */
     --comp-statebrowser-fg: #fff;
-    --comp-statebrowser-bg: #4dafc5;
+    --comp-statebrowser-bg: #096579;
     --comp-statebrowser-bg-networkname: #80c8d8;
     --comp-statebrowser-channel-active-bg: #ffffff0d;
     --comp-statebrowser-channel-active-fg: #fff;
@@ -68,7 +68,7 @@
 
 /* Sidebar */
 .kiwi-aboutbuffer h4 {
-    background-color: #74c9dd;
+    background-color: #0f7890;
 }
 
 /* IRC Text Colours */


### PR DESCRIPTION
I've gone over our current themes and made small improvements to ensure the text is easy to read for our users. The biggest change is to the Sky theme. Most of the other themes seem to be fine, other than Radioactive - Radioactive is considered 'unsupported' as it's such an experimental theme.