### PR TITLE
Sidebar styling update

### DIFF
--- a/src/components/Container.vue
+++ b/src/components/Container.vue
@@ -389,7 +389,7 @@ export default {
     }
 
     .kiwi-sidebar {
-        top: 0;
+        top: -4px;
     }
 }
 

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -299,17 +299,22 @@ export default {
 
     .kiwi-sidebar-options .kiwi-sidebar-close {
         width: 100%;
-        display: inline-block;
-        padding: 0 20px 0 40px;
+        display: block;
+        padding: 0 15px;
+        height: 50px;
+        line-height: 50px;
         text-align: right;
         box-sizing: border-box;
+        letter-spacing: 2px;
         transition: background 0.3s;
     }
 
     .kiwi-sidebar-options .kiwi-sidebar-close i {
-        margin-left: 10px;
+        margin-left: 5px;
         font-size: 1.5em;
         line-height: 47px;
+        position: relative;
+        top: 2px;
     }
 
     .kiwi-sidebar .u-tabbed-view-tab {
@@ -332,7 +337,7 @@ export default {
 
     .kiwi-container--sidebar-drawn .kiwi-sidebar {
         width: 100%;
-        max-width: 100%;
+        max-width: 380px;
     }
 
     .kiwi-sidebar-buffersettings {

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -337,6 +337,7 @@ export default {
 
     .kiwi-container--sidebar-drawn .kiwi-sidebar {
         width: 100%;
+        max-width: 100%;
     }
 
     .kiwi-sidebar-buffersettings {

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -337,7 +337,6 @@ export default {
 
     .kiwi-container--sidebar-drawn .kiwi-sidebar {
         width: 100%;
-        max-width: 380px;
     }
 
     .kiwi-sidebar-buffersettings {

--- a/src/components/SidebarAboutBuffer.vue
+++ b/src/components/SidebarAboutBuffer.vue
@@ -179,7 +179,6 @@ export default {
 
 @media screen and (max-width: 769px) {
     .kiwi-sidebar.kiwi-sidebar-section-about {
-        max-width: 380px;
         width: 100%;
     }
 }

--- a/src/components/SidebarAboutBuffer.vue
+++ b/src/components/SidebarAboutBuffer.vue
@@ -180,6 +180,7 @@ export default {
 @media screen and (max-width: 769px) {
     .kiwi-sidebar.kiwi-sidebar-section-about {
         width: 100%;
+        max-width: 100%;
     }
 }
 </style>

--- a/src/components/SidebarAboutBuffer.vue
+++ b/src/components/SidebarAboutBuffer.vue
@@ -179,7 +179,7 @@ export default {
 
 @media screen and (max-width: 769px) {
     .kiwi-sidebar.kiwi-sidebar-section-about {
-        max-width: 100%;
+        max-width: 380px;
         width: 100%;
     }
 }


### PR DESCRIPTION
This small PR makes the sidebars for mobile / tablet much better all around with three simple fixes.

- Sidebars for table now sit at the top of Kiwi ( top: -4px )
- Adjusted the lineheight and spacing of the sidebar close section, looks much better now
- Made ALL sidebars the same max width for tablet/mobile devices - feels much better to use now

edit: closes #922 