### PR TITLE
Stop buffer close icon overlapping labels on hover

### DIFF
--- a/src/components/StateBrowserNetwork.vue
+++ b/src/components/StateBrowserNetwork.vue
@@ -426,7 +426,7 @@ export default {
     text-align: center;
     z-index: 0;
     top: 0;
-    transition: right 0.2s, opacity 0.2s;
+    transition: opacity 0.2s;
 }
 
 .kiwi-statebrowser-channel-label {

--- a/src/components/StateBrowserNetwork.vue
+++ b/src/components/StateBrowserNetwork.vue
@@ -557,6 +557,11 @@ export default {
         opacity: 1;
         line-height: 40px;
     }
+
+    .kiwi-statebrowser-channel .kiwi-statebrowser-channel-labels {
+        right: 28px;
+        top: 5px;
+    }
 }
 
 </style>

--- a/src/components/StateBrowserNetwork.vue
+++ b/src/components/StateBrowserNetwork.vue
@@ -422,8 +422,7 @@ export default {
 .kiwi-statebrowser-channel-labels {
     position: absolute;
     right: 0;
-    width: 50px;
-    text-align: center;
+    text-align: right;
     z-index: 0;
     top: 0;
     transition: opacity 0.2s;
@@ -435,8 +434,11 @@ export default {
     line-height: 30px;
     height: 30px;
     margin: 0;
-    border-radius: 5px 0 0 5px;
     font-weight: 600;
+    box-sizing: border-box;
+    text-align: center;
+    width: 50px;
+    border-radius: 0;
 }
 
 .kiwi-statebrowser-channel-label:hover {
@@ -554,15 +556,24 @@ export default {
         line-height: 40px;
     }
 
+    .kiwi-network-name-option {
+        width: 50px;
+    }
+
     .kiwi-statebrowser-channel .kiwi-statebrowser-channel-leave {
         opacity: 1;
         line-height: 40px;
-        width: 35px;
+        width: 50px;
     }
 
     .kiwi-statebrowser-channel .kiwi-statebrowser-channel-labels {
-        right: 35px;
-        top: 5px;
+        right: 50px;
+        top: 0;
+    }
+
+    .kiwi-statebrowser-channel .kiwi-statebrowser-channel-label {
+        line-height: 41px;
+        height: 40px;
     }
 }
 

--- a/src/components/StateBrowserNetwork.vue
+++ b/src/components/StateBrowserNetwork.vue
@@ -547,7 +547,7 @@ export default {
 }
 
 @media screen and (max-width: 769px) {
-    .kiwi-statebrowser-network-header .kiwi-network-name-options {
+    .kiwi-network-name-options {
         right: 0;
         opacity: 1;
     }
@@ -560,18 +560,18 @@ export default {
         width: 50px;
     }
 
-    .kiwi-statebrowser-channel .kiwi-statebrowser-channel-leave {
+    .kiwi-statebrowser-channel-leave {
         opacity: 1;
         line-height: 40px;
         width: 50px;
     }
 
-    .kiwi-statebrowser-channel .kiwi-statebrowser-channel-labels {
+    .kiwi-statebrowser-channel-labels {
         right: 50px;
         top: 0;
     }
 
-    .kiwi-statebrowser-channel .kiwi-statebrowser-channel-label {
+    .kiwi-statebrowser-channel-label {
         line-height: 41px;
         height: 40px;
     }

--- a/src/components/StateBrowserNetwork.vue
+++ b/src/components/StateBrowserNetwork.vue
@@ -133,7 +133,7 @@
                                 ]"
                                 class="kiwi-statebrowser-channel-label"
                             >
-                                {{ buffer.flags.unread }}
+                                {{ buffer.flags.unread > 999 ? "999+": buffer.flags.unread }}
                             </div>
                         </transition>
                     </div>
@@ -422,9 +422,11 @@ export default {
 .kiwi-statebrowser-channel-labels {
     position: absolute;
     right: 0;
+    width: 50px;
     text-align: center;
     z-index: 0;
     top: 0;
+    transition: right 0.2s, opacity 0.2s;
 }
 
 .kiwi-statebrowser-channel-label {
@@ -454,7 +456,7 @@ export default {
 .kiwi-statebrowser-channel-leave {
     float: right;
     opacity: 0;
-    width: 28px;
+    width: 50px;
     cursor: pointer;
     margin-right: 0;
     transition: all 0.3s;
@@ -552,14 +554,14 @@ export default {
         line-height: 40px;
     }
 
-    .kiwi-statebrowser-channel .kiwi-statebrowser-channel-settings,
     .kiwi-statebrowser-channel .kiwi-statebrowser-channel-leave {
         opacity: 1;
         line-height: 40px;
+        width: 35px;
     }
 
     .kiwi-statebrowser-channel .kiwi-statebrowser-channel-labels {
-        right: 28px;
+        right: 35px;
         top: 5px;
     }
 }

--- a/src/components/StateBrowserNetwork.vue
+++ b/src/components/StateBrowserNetwork.vue
@@ -454,7 +454,7 @@ export default {
 .kiwi-statebrowser-channel-leave {
     float: right;
     opacity: 0;
-    width: 35px;
+    width: 28px;
     cursor: pointer;
     margin-right: 0;
     transition: all 0.3s;
@@ -464,6 +464,10 @@ export default {
 .kiwi-statebrowser-channel:hover .kiwi-statebrowser-channel-settings,
 .kiwi-statebrowser-channel:hover .kiwi-statebrowser-channel-leave {
     opacity: 1;
+}
+
+.kiwi-statebrowser-channel:hover .kiwi-statebrowser-channel-labels {
+    opacity: 0;
 }
 
 /* Add channel input */

--- a/src/components/StateBrowserNetwork.vue
+++ b/src/components/StateBrowserNetwork.vue
@@ -575,6 +575,11 @@ export default {
         line-height: 41px;
         height: 40px;
     }
+
+    /* Ensure that on mobile devices, when hovering this is visible */
+    .kiwi-statebrowser-channel:hover .kiwi-statebrowser-channel-labels {
+        opacity: 1;
+    }
 }
 
 </style>

--- a/static/themes/coffee/theme.css
+++ b/static/themes/coffee/theme.css
@@ -107,6 +107,10 @@
     color: #fff;
 }
 
+.kiwi-statebrowser-channel-label {
+    background: #967f70;
+}
+
 
 /* IRC Text Colours */
 .irc-fg-colour-white { color: #fff; }

--- a/static/themes/common/base.css
+++ b/static/themes/common/base.css
@@ -455,10 +455,6 @@
     color: var(--comp-statebrowser-fg);
 }
 
-.kiwi-statebrowser-channel .kiwi-statebrowser-channel-name .kiwi-statebrowser-channel-label {
-    background: var(--brand-error);
-}
-
 .kiwi-statebrowser-channel-active {
     border-left-color: var(--brand-primary);
     background: var(--comp-statebrowser-channel-active-bg);
@@ -518,11 +514,6 @@
 
 .kiwi-statebrowser-channel-notjoined .kiwi-statebrowser-channel-name {
     color: var(--brand-error);
-}
-
-.kiwi-statebrowser-channel-label {
-    background: var(--brand-primary);
-    color: var(--brand-default-bg);
 }
 
 .kiwi-statebrowser-channel-popup {

--- a/static/themes/common/base.css
+++ b/static/themes/common/base.css
@@ -566,6 +566,9 @@
     font-weight: 100;
 }
 
+.kiwi-statebrowser-channel-label {
+    background: var(--brand-primary);
+}
 .kiwi-statebrowser-channel-label--highlight {
     background: var(--brand-error);
 }
@@ -668,6 +671,10 @@
 
 .kiwi-container-toggledraw-statebrowser-messagecount--highlight::after {
     border-right-color: var(--brand-error);
+}
+
+.kiwi-wrap--statebrowser-drawopen .kiwi-container-toggledraw-statebrowser-messagecount {
+    background-color: var(--brand-primary);
 }
 
 .kiwi-wrap--statebrowser-drawopen .kiwi-container-toggledraw-statebrowser-messagecount::after {

--- a/static/themes/nightswatch/theme.css
+++ b/static/themes/nightswatch/theme.css
@@ -281,6 +281,10 @@ button.u-button.u-button-primary.u-submit.kiwi-welcome-znc-start,
     color: var(--brand-default-fg);
 }
 
+.kiwi-statebrowser-channel-label {
+    background: #383838;
+}
+
 .kiwi-welcome-znc h2,
 .kiwi-welcome-znc-form .u-input-text-label {
     color: var(--brand-default-bg);

--- a/static/themes/radioactive/theme.css
+++ b/static/themes/radioactive/theme.css
@@ -1030,10 +1030,6 @@
 .kiwi-statebrowser-channel-active .kiwi-statebrowser-channel-name {
     color: #df6b26;
 }
-.kiwi-statebrowser-channel-label {
-    background: #1b2f24;
-    color: #fff;
-}
 .kiwi-statebrowser-channel-label--highlight {
     background: #d62323;
 }
@@ -1056,10 +1052,6 @@
     background: rgba(255, 255, 255, 0.15);
 }
 
-.kiwi-statebrowser-channel-label {
-    background: #1b2f24;
-    color: #dedede;
-}
 .kiwi-statebrowser-channel-label--highlight {
     background: #d62323;
 }


### PR DESCRIPTION
This small PR makes it so the channel label hides when you hover over a channel, inside the statebrowser.


On mobile, the label is now displayed on the left of the 'leave channel' icon.

A quick PR but solves two big issues. Fixes #932  