### PR TITLE
fix error when removing network

### DIFF
--- a/src/libs/IrcClient.js
+++ b/src/libs/IrcClient.js
@@ -1146,6 +1146,11 @@ function clientMiddleware(state, network) {
                 buffer = network.serverBuffer();
             }
 
+            if (!buffer) {
+                // we could not find a buffer, this is likely because the network was removed
+                return;
+            }
+
             // TODO: Some of these errors contain a .error property whcih we can match against,
             // ie. password_mismatch.
 


### PR DESCRIPTION
```
TypeError: Cannot read property 'isChannel' of null
    at parsedEventsHandler (IrcClient.js?c859:1070)
    at s (browser.js?2f5d:8)
    at i.handle (browser.js?2f5d:8)
    at eval (browser.js?2f5d:8)
    at e.a.emit (browser.js?2f5d:1)
    at emit (browser.js?2f5d:8)
    at eval (browser.js?2f5d:8)
    at e.value (browser.js?2f5d:8)
    at e.value (browser.js?2f5d:8)
    at eval (browser.js?2f5d:8)
```

```
if (_buffer19.isChannel() && !_buffer19.joined) {
    _buffer19.enabled = false;
}
```