### PR TITLE
Make timestamp visible on inline messagelist 

### DIFF
--- a/src/components/MessageListMessageInline.vue
+++ b/src/components/MessageListMessageInline.vue
@@ -129,7 +129,6 @@ export default {
 //display timestamp when hovering over the message
 .kiwi-messagelist-message--text:hover .kiwi-messagelist-time {
     display: block;
-    background: #fff;
     border-radius: 5px 0 0 5px;
 }
 

--- a/static/themes/common/base.css
+++ b/static/themes/common/base.css
@@ -852,6 +852,11 @@
     background-color: var(--brand-default-fg);
 }
 
+/* Messagelayout inline */
+.kiwi-messagelist-message--text .kiwi-messagelist-time {
+    color: var(--brand-default-fg);
+}
+
 /* Connection Styling */
 .kiwi-messagelist-message-connection {
     background-color: var(--brand-default-bg);


### PR DESCRIPTION
- Remove background colour from messagelist inline timestamp
- Add default colour to the messagelist inline timestamp in the base.css theme file

This fixes: #918 :) 