### PR TITLE
Update the styling of the typing user list

### DIFF
--- a/src/components/ControlInput.vue
+++ b/src/components/ControlInput.vue
@@ -837,6 +837,10 @@ export default {
 .kiwi-typinguserslist {
     position: absolute;
     top: -24px;
-    background: var(--brand-default-bg);
+    width: 100%;
+    padding: 0 20px;
+    box-sizing: border-box;
+    text-align: left;
+    left: 0;
 }
 </style>


### PR DESCRIPTION
Should help with #1016 

- Remove background from the typing notification container
- Position the typing container flush left with the messageList
- Added padding to accommodate for a huge typing list of users
- Align left stops the users from simply centering on mobile devices

![image](https://user-images.githubusercontent.com/11334905/58625780-168fb700-82cb-11e9-911c-71daa86aacb2.png)
