### PR TITLE
Add 'View plaintext password' to welcome startup screen

### DIFF
--- a/src/components/NetworkSettings.vue
+++ b/src/components/NetworkSettings.vue
@@ -364,8 +364,6 @@ export default {
     .kiwi-networksettings input[type='email'],
     .kiwi-networksettings textarea,
     .kiwi-networksettings .u-input-text input {
-    clear: both;
-    width: 100%;
     height: 40px;
     padding: 0 10px;
     line-height: 40px;
@@ -375,6 +373,13 @@ export default {
     overflow-x: hidden;
     overflow-y: auto;
     max-width: none;
+}
+
+.kiwi-networksettings input[type='text'],
+    .kiwi-networksettings input[type='email'],
+    .kiwi-networksettings textarea {
+    clear: both;
+    width: 100%;
 }
 
 .kiwi-networksettings .u-input-text {

--- a/src/components/NetworkSettings.vue
+++ b/src/components/NetworkSettings.vue
@@ -20,6 +20,7 @@
                 <div class="kiwi-networksettings-connection-password">
                     <template v-if="server_type==='network'">
                         <input-text
+                            :show-plain-text="true"
                             :label="$t('password')"
                             v-model="network.password"
                             type="password"

--- a/src/components/startups/Welcome.vue
+++ b/src/components/startups/Welcome.vue
@@ -33,10 +33,17 @@
                     v-focus
                     v-if="showPass && (show_password_box || !toggablePass)"
                     :label="$t('password')"
+                    :type="showPlainText ? 'text' : 'password'"
                     v-model="password"
                     class="kiwi-welcome-simple-password u-input-text--reveal-value"
-                    type="password"
                 />
+                <label
+                    v-if="showPass && (show_password_box || !toggablePass)"
+                    class="kiwi-welcome-simple-have-password"
+                >
+                    <input v-model="showPlainText" type="checkbox" >
+                    <span> Display password as plaintext? </span>
+                </label>
                 <input-text
                     v-if="showChannel"
                     :label="$t('channel')"
@@ -94,6 +101,7 @@ export default {
             recaptchaSiteId: '',
             recaptchaResponseCache: '',
             connectWithoutChannel: false,
+            showPlainText: false,
         };
     },
     computed: {

--- a/src/components/startups/Welcome.vue
+++ b/src/components/startups/Welcome.vue
@@ -29,23 +29,16 @@
                     <input v-model="show_password_box" type="checkbox" >
                     <span> {{ $t('password_have') }} </span>
                 </label>
-                <div class="kiwi-password-input-container">
-                    <input-text
-                        v-focus
-                        v-if="showPass && (show_password_box || !toggablePass)"
-                        :label="$t('password')"
-                        :type="showPlainText ? 'text' : 'password'"
-                        v-model="password"
-                        class="kiwi-welcome-simple-password u-input-text--reveal-value"
-                    />
-                    <i
-                        v-if="showPass && (show_password_box || !toggablePass)"
-                        :class="{active: showPlainText}"
-                        class="fa fa-eye kiwi-show-plaintext"
-                        aria-hidden="true"
-                        @click="showPlainText = !showPlainText"
-                    />
-                </div>
+
+                <input-text
+                    v-focus
+                    v-if="showPass && (show_password_box || !toggablePass)"
+                    :label="$t('password')"
+                    :show-plain-text="true"
+                    v-model="password"
+                    type="password"
+                    class="kiwi-welcome-simple-password u-input-text--reveal-value"
+                />
 
                 <input-text
                     v-if="showChannel"
@@ -410,28 +403,6 @@ export default {
 .kiwi-welcome-simple-start[disabled] {
     cursor: not-allowed;
     opacity: 0.65;
-}
-
-.kiwi-password-input-container {
-    position: relative;
-}
-
-.kiwi-show-plaintext {
-    position: absolute;
-    bottom: 0;
-    right: 0;
-    height: 40px;
-    line-height: 40px;
-    width: 40px;
-    text-align: center;
-    cursor: pointer;
-    opacity: 0.5;
-    transition: opacity 0.2s;
-}
-
-.kiwi-show-plaintext.active,
-.kiwi-show-plaintext:hover {
-    opacity: 1;
 }
 
 .kiwi-welcome-simple-channel {

--- a/src/components/startups/Welcome.vue
+++ b/src/components/startups/Welcome.vue
@@ -29,21 +29,24 @@
                     <input v-model="show_password_box" type="checkbox" >
                     <span> {{ $t('password_have') }} </span>
                 </label>
-                <input-text
-                    v-focus
-                    v-if="showPass && (show_password_box || !toggablePass)"
-                    :label="$t('password')"
-                    :type="showPlainText ? 'text' : 'password'"
-                    v-model="password"
-                    class="kiwi-welcome-simple-password u-input-text--reveal-value"
-                />
-                <label
-                    v-if="showPass && (show_password_box || !toggablePass)"
-                    class="kiwi-welcome-simple-have-password"
-                >
-                    <input v-model="showPlainText" type="checkbox" >
-                    <span> Display password as plaintext? </span>
-                </label>
+                <div class="kiwi-password-input-container">
+                    <input-text
+                        v-focus
+                        v-if="showPass && (show_password_box || !toggablePass)"
+                        :label="$t('password')"
+                        :type="showPlainText ? 'text' : 'password'"
+                        v-model="password"
+                        class="kiwi-welcome-simple-password u-input-text--reveal-value"
+                    />
+                    <i
+                        v-if="showPass && (show_password_box || !toggablePass)"
+                        :class="{active: showPlainText}"
+                        class="fa fa-eye kiwi-show-plaintext"
+                        aria-hidden="true"
+                        @click="showPlainText = !showPlainText"
+                    />
+                </div>
+
                 <input-text
                     v-if="showChannel"
                     :label="$t('channel')"
@@ -407,6 +410,28 @@ export default {
 .kiwi-welcome-simple-start[disabled] {
     cursor: not-allowed;
     opacity: 0.65;
+}
+
+.kiwi-password-input-container {
+    position: relative;
+}
+
+.kiwi-show-plaintext {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    height: 40px;
+    line-height: 40px;
+    width: 40px;
+    text-align: center;
+    cursor: pointer;
+    opacity: 0.5;
+    transition: opacity 0.2s;
+}
+
+.kiwi-show-plaintext.active,
+.kiwi-show-plaintext:hover {
+    opacity: 1;
 }
 
 .kiwi-welcome-simple-channel {

--- a/src/components/startups/Welcome.vue
+++ b/src/components/startups/Welcome.vue
@@ -97,7 +97,6 @@ export default {
             recaptchaSiteId: '',
             recaptchaResponseCache: '',
             connectWithoutChannel: false,
-            showPlainText: false,
         };
     },
     computed: {

--- a/src/components/utils/InputText.vue
+++ b/src/components/utils/InputText.vue
@@ -12,8 +12,8 @@
         <template v-if="type==='password'">
             <input
                 v-model="currentValue"
-                :type="plainTextEnabled && !checkIfEdge() ? 'text' : 'password'"
-                :class="{'u-form-input-plaintext' : !checkIfEdge() && showPlainText}"
+                :type="plainTextEnabled && !isEdgeBrowser() ? 'text' : 'password'"
+                :class="{'u-form-input-plaintext' : !isEdgeBrowser() && showPlainText}"
                 autocomplete="off"
                 autocorrect="off"
                 autocapitalize="off" spellcheck="false"
@@ -21,9 +21,9 @@
             >
 
             <i
-                v-if="showPlainText && !checkIfEdge()"
+                v-if="showPlainText && !isEdgeBrowser()"
                 :class="{active: plainTextEnabled}"
-                class="fa fa-eye kiwi-show-plaintext"
+                class="fa fa-eye u-input-plaintext"
                 aria-hidden="true"
                 @click="plainTextEnabled = !plainTextEnabled"
             />
@@ -81,7 +81,7 @@ export default Vue.component('input-text', {
         updateValue: function updateValue(newValue) {
             this.$emit('input', newValue);
         },
-        checkIfEdge() {
+        isEdgeBrowser() {
             return navigator.appVersion.indexOf('Edge') > -1;
         },
     },
@@ -169,7 +169,7 @@ input[type=password].u-form-input-plaintext {
     padding-right: 0;
 }
 
-.kiwi-show-plaintext {
+.u-input-plaintext {
     display: inline-block;
     line-height: 40px;
     width: 30px;
@@ -179,8 +179,8 @@ input[type=password].u-form-input-plaintext {
     transition: opacity 0.2s;
 }
 
-.kiwi-show-plaintext.active,
-.kiwi-show-plaintext:hover {
+.u-input-plaintext.active,
+.u-input-plaintext:hover {
     opacity: 1;
 }
 

--- a/src/components/utils/InputText.vue
+++ b/src/components/utils/InputText.vue
@@ -9,23 +9,25 @@
 
         <span class="u-input-text-label">{{ label }}</span>
 
-        <i
-            v-if="showPlainText"
-            :class="{active: plainTextEnabled}"
-            class="fa fa-eye kiwi-show-plaintext"
-            aria-hidden="true"
-            @click="plainTextEnabled = !plainTextEnabled"
-        />
+        <template v-if="type==='password'">
+            <input
+                v-model="currentValue"
+                :type="plainTextEnabled ? 'text' : 'password'"
+                :class="{inputPlainText: showPlainText}"
+                autocomplete="off"
+                autocorrect="off"
+                autocapitalize="off" spellcheck="false"
+                @focus="hasFocus=true" @blur="hasFocus=false"
+            >
 
-        <input
-            v-if="type==='password'"
-            v-model="currentValue"
-            :type="plainTextEnabled ? 'text' : 'password'"
-            :class="{inputPlainText: showPlainText}"
-            autocomplete="off"
-            autocorrect="off"
-            autocapitalize="off" spellcheck="false" @focus="hasFocus=true" @blur="hasFocus=false"
-        >
+            <i
+                v-if="showPlainText"
+                :class="{active: plainTextEnabled}"
+                class="fa fa-eye kiwi-show-plaintext"
+                aria-hidden="true"
+                @click="plainTextEnabled = !plainTextEnabled"
+            />
+        </template>
 
         <input
             v-else-if="type==='number'"
@@ -98,6 +100,7 @@ export default Vue.component('input-text', {
     border: none;
     outline: none;
     line-height: 1.6em;
+    border-bottom: none;
     font-size: 0.9em;
 }
 
@@ -157,16 +160,17 @@ export default Vue.component('input-text', {
 
 input[type=text].inputPlainText,
 input[type=password].inputPlainText {
-    padding-right: 40px;
+    display: inline-block;
+    width: calc(100% - 34px);
+    border-bottom: 0;
+    padding-right: 0;
 }
 
 .kiwi-show-plaintext {
-    position: absolute;
-    bottom: 0;
-    right: 0;
+    display: inline-block;
     height: 40px;
     line-height: 40px;
-    width: 40px;
+    width: 30px;
     text-align: center;
     cursor: pointer;
     opacity: 0.5;

--- a/src/components/utils/InputText.vue
+++ b/src/components/utils/InputText.vue
@@ -22,9 +22,8 @@
 
             <i
                 v-if="showPlainText && !isEdgeBrowser()"
-                :class="{'u-input-text-plaintext': !plainTextEnabled,
-                         'u-input-text-plaintext--active': plainTextEnabled }"
-                class="fa fa-eye"
+                :class="{'u-input-text-plaintext--active': plainTextEnabled}"
+                class="u-input-text-plaintext fa fa-eye"
                 aria-hidden="true"
                 @click="plainTextEnabled = !plainTextEnabled"
             />

--- a/src/components/utils/InputText.vue
+++ b/src/components/utils/InputText.vue
@@ -22,8 +22,8 @@
 
             <i
                 v-if="showPlainText && !isEdgeBrowser()"
-                :class="{active: plainTextEnabled}"
-                class="fa fa-eye u-input-plaintext"
+                :class="{'u-input-text-plaintext': !plainTextEnabled, 'u-input-text-plaintext--active': plainTextEnabled }"
+                class="fa fa-eye"
                 aria-hidden="true"
                 @click="plainTextEnabled = !plainTextEnabled"
             />
@@ -169,7 +169,7 @@ input[type=password].u-form-input-plaintext {
     padding-right: 0;
 }
 
-.u-input-plaintext {
+.u-input-text-plaintext {
     display: inline-block;
     line-height: 40px;
     width: 30px;
@@ -179,8 +179,8 @@ input[type=password].u-form-input-plaintext {
     transition: opacity 0.2s;
 }
 
-.u-input-plaintext.active,
-.u-input-plaintext:hover {
+.u-input-text-plaintext--active,
+.u-input-text-plaintext:hover {
     opacity: 1;
 }
 

--- a/src/components/utils/InputText.vue
+++ b/src/components/utils/InputText.vue
@@ -12,8 +12,8 @@
         <template v-if="type==='password'">
             <input
                 v-model="currentValue"
-                :type="plainTextEnabled ? 'text' : 'password'"
-                :class="{inputPlainText: showPlainText}"
+                :type="plainTextEnabled && !checkIfEdge() ? 'text' : 'password'"
+                :class="{'u-form-input-plaintext' : !checkIfEdge() && showPlainText}"
                 autocomplete="off"
                 autocorrect="off"
                 autocapitalize="off" spellcheck="false"
@@ -21,7 +21,7 @@
             >
 
             <i
-                v-if="showPlainText"
+                v-if="showPlainText && !checkIfEdge()"
                 :class="{active: plainTextEnabled}"
                 class="fa fa-eye kiwi-show-plaintext"
                 aria-hidden="true"
@@ -80,6 +80,9 @@ export default Vue.component('input-text', {
     methods: {
         updateValue: function updateValue(newValue) {
             this.$emit('input', newValue);
+        },
+        checkIfEdge() {
+            return navigator.appVersion.indexOf('Edge') > -1;
         },
     },
 });
@@ -158,17 +161,16 @@ export default Vue.component('input-text', {
     margin: 0;
 }
 
-input[type=text].inputPlainText,
-input[type=password].inputPlainText {
+input[type=text].u-form-input-plaintext,
+input[type=password].u-form-input-plaintext {
     display: inline-block;
-    width: calc(100% - 34px);
+    width: calc(100% - 35px);
     border-bottom: 0;
     padding-right: 0;
 }
 
 .kiwi-show-plaintext {
     display: inline-block;
-    height: 40px;
     line-height: 40px;
     width: 30px;
     text-align: center;

--- a/src/components/utils/InputText.vue
+++ b/src/components/utils/InputText.vue
@@ -23,7 +23,7 @@
             <i
                 v-if="showPlainText && !isEdgeBrowser()"
                 :class="{'u-input-text-plaintext': !plainTextEnabled,
-                'u-input-text-plaintext--active': plainTextEnabled }"
+                         'u-input-text-plaintext--active': plainTextEnabled }"
                 class="fa fa-eye"
                 aria-hidden="true"
                 @click="plainTextEnabled = !plainTextEnabled"

--- a/src/components/utils/InputText.vue
+++ b/src/components/utils/InputText.vue
@@ -9,14 +9,23 @@
 
         <span class="u-input-text-label">{{ label }}</span>
 
+        <i
+            v-if="showPlainText"
+            :class="{active: plainTextEnabled}"
+            class="fa fa-eye kiwi-show-plaintext"
+            aria-hidden="true"
+            @click="plainTextEnabled = !plainTextEnabled"
+        />
+
         <input
             v-if="type==='password'"
             v-model="currentValue"
-            type="password"
+            :type="plainTextEnabled ? 'text' : 'password'"
             autocomplete="off"
             autocorrect="off"
             autocapitalize="off" spellcheck="false" @focus="hasFocus=true" @blur="hasFocus=false"
         >
+
         <input
             v-else-if="type==='number'"
             v-model="currentValue"
@@ -48,9 +57,10 @@
 let Vue = require('vue');
 
 export default Vue.component('input-text', {
-    props: ['value', 'label', 'type'],
+    props: ['value', 'label', 'type', 'showPlainText'],
     data: function data() {
         return {
+            plainTextEnabled: false,
             hasFocus: false,
         };
     },
@@ -142,6 +152,24 @@ export default Vue.component('input-text', {
     /* For webkit browsers like Safari and Chrome */
     -webkit-appearance: none;
     margin: 0;
+}
+
+.kiwi-show-plaintext {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    height: 40px;
+    line-height: 40px;
+    width: 40px;
+    text-align: center;
+    cursor: pointer;
+    opacity: 0.5;
+    transition: opacity 0.2s;
+}
+
+.kiwi-show-plaintext.active,
+.kiwi-show-plaintext:hover {
+    opacity: 1;
 }
 
 </style>

--- a/src/components/utils/InputText.vue
+++ b/src/components/utils/InputText.vue
@@ -22,7 +22,8 @@
 
             <i
                 v-if="showPlainText && !isEdgeBrowser()"
-                :class="{'u-input-text-plaintext': !plainTextEnabled, 'u-input-text-plaintext--active': plainTextEnabled }"
+                :class="{'u-input-text-plaintext': !plainTextEnabled,
+                'u-input-text-plaintext--active': plainTextEnabled }"
                 class="fa fa-eye"
                 aria-hidden="true"
                 @click="plainTextEnabled = !plainTextEnabled"

--- a/src/components/utils/InputText.vue
+++ b/src/components/utils/InputText.vue
@@ -21,6 +21,7 @@
             v-if="type==='password'"
             v-model="currentValue"
             :type="plainTextEnabled ? 'text' : 'password'"
+            :class="{inputPlainText: showPlainText}"
             autocomplete="off"
             autocorrect="off"
             autocapitalize="off" spellcheck="false" @focus="hasFocus=true" @blur="hasFocus=false"
@@ -152,6 +153,11 @@ export default Vue.component('input-text', {
     /* For webkit browsers like Safari and Chrome */
     -webkit-appearance: none;
     margin: 0;
+}
+
+input[type=text].inputPlainText,
+input[type=password].inputPlainText {
+    padding-right: 40px;
 }
 
 .kiwi-show-plaintext {


### PR DESCRIPTION
This looks at adding in the suggestion of #986 

We now have an additional checkbox under the password field that will toggle between a password field and a standard text field for the user.

![image](https://user-images.githubusercontent.com/11334905/58626622-23150f00-82cd-11e9-8b79-33a31a1da76d.png)

![image](https://user-images.githubusercontent.com/11334905/58626646-2d370d80-82cd-11e9-90ab-0a3b873e4661.png)

