### PR TITLE
[ui] Widen nick column in compact on wider screens, fix mobile

### DIFF
--- a/src/components/MessageListMessageCompact.vue
+++ b/src/components/MessageListMessageCompact.vue
@@ -231,7 +231,8 @@ export default {
     opacity: 1;
 }
 
-@media screen and (max-width: 700px) {
+// Mobile layout (matches this.$state.ui.is_narrow)
+@media screen and (max-width: 769px) {
     .kiwi-messagelist-message--compact {
         padding: 5px;
     }

--- a/src/components/MessageListMessageCompact.vue
+++ b/src/components/MessageListMessageCompact.vue
@@ -291,4 +291,66 @@ export default {
     margin-bottom: 5px;
 }
 
+// Moderate screen size
+// Give more space to the nickname column on larger screens
+@media screen and (min-width: 1000px) {
+    // Nicknames
+    .kiwi-messagelist-message--compact .kiwi-messagelist-nick {
+        width: 160px;
+        min-width: 160px;
+    }
+
+    .kiwi-messagelist-message--compact .kiwi-messagelist-nick:hover {
+        width: auto;
+    }
+
+    // Messages
+    .kiwi-messagelist-message--compact .kiwi-messagelist-body {
+        margin-left: 170px;
+    }
+
+    .kiwi-messagelist-message--compact .kiwi-messageinfo {
+        padding-left: 180px;
+    }
+
+    .kiwi-messagelist-message--compact.kiwi-messagelist-message-traffic .kiwi-messagelist-body {
+        margin-left: 181px;
+    }
+
+    .kiwi-messagelist-message--compact.kiwi-messagelist-message-connection .kiwi-messagelist-body {
+        margin-left: 181px;
+    }
+}
+
+// Widescreen
+// Give the most space to the nickname column on even wider screens
+@media screen and (min-width: 1300px) {
+    // Nicknames
+    .kiwi-messagelist-message--compact .kiwi-messagelist-nick {
+        width: 210px;
+        min-width: 210px;
+    }
+
+    .kiwi-messagelist-message--compact .kiwi-messagelist-nick:hover {
+        width: auto;
+    }
+
+    // Messages
+    .kiwi-messagelist-message--compact .kiwi-messagelist-body {
+        margin-left: 220px;
+    }
+
+    .kiwi-messagelist-message--compact .kiwi-messageinfo {
+        padding-left: 230px;
+    }
+
+    .kiwi-messagelist-message--compact.kiwi-messagelist-message-traffic .kiwi-messagelist-body {
+        margin-left: 231px;
+    }
+
+    .kiwi-messagelist-message--compact.kiwi-messagelist-message-connection .kiwi-messagelist-body {
+        margin-left: 231px;
+    }
+}
+
 </style>


### PR DESCRIPTION
## In short
* Adjust compact layout's nickname column width according to screen size
  * On wider screens, longer nicknames can be seen without hovering
  * Helps avoid nicknames looking the same
* Fix compact layout mobile CSS breakpoint
  * Match `this.$state.ui.is_narrow` of `769px`
  * Fixes oddities at the fringe of mobile browser size

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | Longer nicks more visible on non-default compact layout
Risk | ★★☆ *2/3* | Might expose new layout issues, protest of new defaults
Intrusiveness | ★☆☆ *1/3* | Minor changes to compact styles, shouldn't interfere with other PRs

## Rationale
On wider screens, there's plenty of free space to show longer nicknames without needing to hover, and the additional variation in nickname length can help with picking out individual messages.

Smaller screens should still get a shortened nickname, conserving space to show more of the messages themselves.

*Values are subject to change, this is just a first pass.*

Separately, the mobile layout breakpoint should match `this.$state.ui.is_narrow` value to avoid an in-between of not-quite-mobile where nicknames are cut off.

## Examples
### Setup
1.  Join a network with `longest_nickname_allowed_here` and `SeventeenCharNik`
2.  Have both nicks send some messages
3.  To try out on an existing install **without this PR**, [paste this CSS into the Style Editor](https://zorro.casa/sync/Hosting/Utilities/Development/KiwiIRC/pr/ft-layout-compact-dynamic-nick/layout%20traditional%20-%20dynamic%20nickname%20columns%20patch.css )
4.  Resize browser window and observe

### :checkered_flag: Mobile (unchanged)

![Kiwi IRC screenshot showing the mobile view, with two nicknames messaging each other.  Nicknames are shown above the messages and are not cut off.](https://zorro.casa/sync/Hosting/Utilities/Development/KiwiIRC/pr/ft-layout-compact-dynamic-nick/Layout%20-%201%20-%20mobile.png#v1 )

### :checkered_flag: Minimal (current desktop UI)

![Kiwi IRC screenshot showing the desktop compact (Traditional) layout, with two nicknames messaging each other.  Nicknames are shown before the messages, cutting off at "Sevente..." and "longest_ni...".](https://zorro.casa/sync/Hosting/Utilities/Development/KiwiIRC/pr/ft-layout-compact-dynamic-nick/Layout%20-%202%20-%20minimal.png#v1 )

### :new: Wider (new)

![Kiwi IRC screenshot showing the desktop compact (Traditional) layout, with two nicknames messaging each other.  Nicknames are shown before the messages, cutting off at "SeventeenChar..." and "longest_nickname...".](https://zorro.casa/sync/Hosting/Utilities/Development/KiwiIRC/pr/ft-layout-compact-dynamic-nick/Layout%20-%203%20-%20wider.png#v1 )

### :new: Widescreen (new)

![Kiwi IRC screenshot showing the desktop compact (Traditional) layout, with two nicknames messaging each other.  Nicknames are shown before the messages, showing the full "SeventeenCharNik" and cutting the other nick off at "longest_nickname_allowe...".](https://zorro.casa/sync/Hosting/Utilities/Development/KiwiIRC/pr/ft-layout-compact-dynamic-nick/Layout%20-%204%20-%20widescreen.png#v1 )

### :heavy_check_mark: Broken mobile in-between layout (fixed)

**Fixed in this pull request, will look the same as `Mobile` above**

This shows what happens at screen widths between `700px` and `769px` before this pull request.

![Kiwi IRC showing the mobile layout, but with nicknames in front of the messages instead of above, as they should be.  The browser is resized to a state between 700px and 769px where the message layout is wrong.](https://zorro.casa/sync/Hosting/Utilities/Development/KiwiIRC/pr/ft-layout-compact-dynamic-nick/Layout%20bug%20-%20mobile%20in-between.png#v1 )