### PR TITLE
Update "Forget me" button color for all themes

### DIFF
--- a/static/themes/common/base.css
+++ b/static/themes/common/base.css
@@ -370,6 +370,10 @@
     background-color: var(--comp-usermenu-open-bg);
 }
 
+.kiwi-statebrowser-usermenu-body .u-link {
+    color: var(--brand-error);
+}
+
 .kiwi-statebrowser-divider {
     background: rgba(255, 255, 255, 0.3);
 }


### PR DESCRIPTION
Making "Forget me" link button color RED for all themes, because in some themes it doesn't get recognized as a button but as text, now it seems more clear for users to specify that this text is a button and not a simple text.

This doesn't apply for Radioactive theme, i tried to do some changes but i cannot figure it why, any ideas are welcome.