### PR TITLE
Fix to display timestamps on Inline style correctly

### DIFF
--- a/src/components/MessageListMessageInline.vue
+++ b/src/components/MessageListMessageInline.vue
@@ -116,13 +116,12 @@ export default {
     text-align: left;
 }
 
-//Hide the timestamp unless the user hovers over the message in question
+//Display the timestamps if "Show timestamps" is enabled
 .kiwi-messagelist-message--text .kiwi-messagelist-time {
     position: absolute;
     top: 0;
     right: 0;
     padding: 0 10px;
-    display: none;
     opacity: 0.8;
 }
 


### PR DESCRIPTION
Currently it doesn't display the timestamps correctly even if the "Show timestamps" option is enabled, i tested by removing the "display: none" and is working perfectly and now it listening the option "Show timestamps" correctly.