### PR TITLE
Only show errors in network settings if we are not registered

### DIFF
--- a/src/libs/IrcClient.js
+++ b/src/libs/IrcClient.js
@@ -1149,7 +1149,9 @@ function clientMiddleware(state, network) {
 
             // ignore error 432 (erroneous nickname) as it is handled above
             if (event.reason && network.last_error_numeric !== 432) {
-                network.last_error = event.reason;
+                if (!isRegistered) {
+                    network.last_error = event.reason;
+                }
                 let messageBody = TextFormatting.formatText('general_error', {
                     text: event.reason || event.error,
                 });


### PR DESCRIPTION
I'm not sure this is the perfect solution but is cleaner than the current situation.

seems overkill to create more complex code to detect if it was attempting to connect at the time of the error

closes #883 