### PR TITLE
Fix nicklist to sort users by their highest channel mode

### DIFF
--- a/src/components/Nicklist.vue
+++ b/src/components/Nicklist.vue
@@ -145,8 +145,8 @@ export default {
                 }
 
                 // Both users have a prefix so find the highest ranking one
-                let aP = prefixOrders[modesA[0]];
-                let bP = prefixOrders[modesB[0]];
+                let aP = prefixOrders[this.buffer.userMode(a)];
+                let bP = prefixOrders[this.buffer.userMode(b)];
                 if (aP > bP) {
                     return 1;
                 } else if (aP < bP) {

--- a/src/libs/state/BufferState.js
+++ b/src/libs/state/BufferState.js
@@ -177,6 +177,11 @@ export default class BufferState {
             return '';
         }
 
+        // if there is only one mode just return it
+        if (modes.length === 1) {
+            return modes[0];
+        }
+
         let network = this.getNetwork();
         let netPrefixes = network.ircClient.network.options.PREFIX;
         // Find the first (highest) netPrefix in the users buffer modes


### PR DESCRIPTION
the current sort is assuming user.buffers['#chan'].modes[0] is the highest mode (when it might not be) which causes sorting issues for users with more then 1 mode.

this pr instead uses bufferState.userMode(user) to get the highest ranking mode for the user

thanks for reporting @westor7 