### PR TITLE
Dark theme URL hyperlink consistency color fixes.

### DIFF
--- a/static/themes/dark/theme.css
+++ b/static/themes/dark/theme.css
@@ -163,6 +163,12 @@ button.u-button.u-button-primary.u-submit.kiwi-welcome-znc-start,
 .kiwi-channellist table tbody tr:nth-child(even) {
     background-color: #333333;
 }
+
+.kiwi-channellist-table-topic a,
+.kiwi-channellist-table-topic a:hover {
+    color: var(--brand-primary);
+}
+
 .kiwi-messagelist-message--own {
     background-color: #2d2d2d;
 }
@@ -174,6 +180,11 @@ button.u-button.u-button-primary.u-submit.kiwi-welcome-znc-start,
 .kiwi-sidebar-options,
 .kiwi-aboutbuffer h4 {
     color: #fff;
+}
+
+.kiwi-aboutbuffer a,
+.kiwi-aboutbuffer a:hover {
+    color: var(--brand-primary);
 }
 
 .kiwi-messagelist .kiwi-messagelist-body a,


### PR DESCRIPTION
I noticed a couple more places where the URL hyperlink colors don't match the theme primary color.

Before and after examples below.

![image](https://user-images.githubusercontent.com/24723440/59380076-84999c80-8d15-11e9-93ca-42376514fab8.png)

![image](https://user-images.githubusercontent.com/24723440/59380098-8d8a6e00-8d15-11e9-8e92-18f77343380e.png)


Ready for review.