### PR TITLE
put @#channel messages into the correct buffers

### DIFF
--- a/src/libs/InputHandler.js
+++ b/src/libs/InputHandler.js
@@ -151,7 +151,13 @@ function handleMessage(type, event, command, line) {
         return;
     }
 
-    let buffer = bufferName.length && this.state.getOrAddBufferByName(network.id, bufferName);
+    let localBuffer = bufferName;
+    let extractedTarget = network.ircClient.network.extractTargetGroup(bufferName);
+    if (extractedTarget) {
+        localBuffer = extractedTarget.target;
+    }
+
+    let buffer = localBuffer.length && this.state.getOrAddBufferByName(network.id, localBuffer);
     if (buffer) {
         let textFormatType = 'privmsg';
         if (type === 'action') {


### PR DESCRIPTION
this fixes the issue, but im not sure if there could be side effects on uncommon sever setups.

I tested sending `/msg @#channel message` as both op and voice, and they arrived in the correct channel, but where locally added to the wrong channel

closes #1052 