### PR TITLE
Respond correctly to bnc sending 'disconnected' state on a network

### DIFF
--- a/src/libs/BouncerMiddleware.js
+++ b/src/libs/BouncerMiddleware.js
@@ -61,6 +61,14 @@ export default function bouncerMiddleware() {
             });
         }
 
+        if (params[0] === 'state' && params[2] === 'disconnected') {
+            let netName = (params[1] || '').toLowerCase();
+            let eventObj = {
+                network: netName,
+            };
+            client.emit('socket close');
+        }
+
         if (params[0] === 'addnetwork' && params[2].substr(0, 4) === 'ERR_') {
             let netName = (params[1] || '').toLowerCase();
             let eventObj = {

--- a/src/libs/BouncerMiddleware.js
+++ b/src/libs/BouncerMiddleware.js
@@ -63,10 +63,9 @@ export default function bouncerMiddleware() {
 
         if (params[0] === 'state' && params[2] === 'disconnected') {
             let netName = (params[1] || '').toLowerCase();
-            let eventObj = {
-                network: netName,
-            };
-            client.emit('socket close');
+            // // eslint-disable-next-line
+            // console.log('emitting socket close for', netName);
+            client.emit('socket close', null, netName);
         }
 
         if (params[0] === 'addnetwork' && params[2].substr(0, 4) === 'ERR_') {

--- a/src/libs/IrcClient.js
+++ b/src/libs/IrcClient.js
@@ -130,10 +130,19 @@ function clientMiddleware(state, network) {
             });
         });
 
-        client.on('socket close', (err) => {
+        client.on('socket close', (err, netName) => {
             isRegistered = false;
             network.state = 'disconnected';
             network.state_error = err || '';
+
+            // bnc-directed close, only continue if the names match
+            // // eslint-disable-next-line
+            // console.log('handling socket close:', network.name.toLowerCase(), netName);
+            if (netName !== null && network.name.toLowerCase() !== netName) {
+                // // eslint-disable-next-line
+                // console.log(' - not for me', network.name);
+                return;
+            }
 
             network.buffers.forEach((buffer) => {
                 if (!buffer) {


### PR DESCRIPTION
Forgot to open this up last week. Pretty simple change, just makes Kiwi respect when a bouncer sends a disconnected state to us (so it doesn't sit there forever in the 'waiting' state.