### PR TITLE
Font color improvements for network channel unread message count.

### DIFF
--- a/static/themes/common/base.css
+++ b/static/themes/common/base.css
@@ -572,6 +572,7 @@
 
 .kiwi-statebrowser-channel-label {
     background: var(--brand-primary);
+    color: var(--brand-default-bg);
 }
 .kiwi-statebrowser-channel-label--highlight {
     background: var(--brand-error);

--- a/static/themes/dark/theme.css
+++ b/static/themes/dark/theme.css
@@ -72,8 +72,7 @@
     color: #000000;
 }
 
-button.u-button.u-button-primary.u-submit.kiwi-welcome-znc-start,
-.kiwi-statebrowser-channel-label {
+button.u-button.u-button-primary.u-submit.kiwi-welcome-znc-start {
     color: var(--brand-default-fg);
 }
 


### PR DESCRIPTION
Dark and Elite these have unreadable message counts. This PR makes subtle changes to use the themes default background variable.

![image](https://user-images.githubusercontent.com/24723440/60921938-dff97480-a258-11e9-8c0e-6f7a8fe0f0dc.png)


