### PR TITLE
Move input history to state/buffer so its maintained when ControlInput is destroyed

### DIFF
--- a/src/components/ControlInput.vue
+++ b/src/components/ControlInput.vue
@@ -135,8 +135,6 @@ export default {
         return {
             self: this,
             selfuser_open: false,
-            history: [],
-            history_pos: 0,
             autocomplete_open: false,
             autocomplete_items: [],
             autocomplete_filter: '',
@@ -185,6 +183,27 @@ export default {
                 return true;
             }
             return false;
+        },
+        history() {
+            if (state.setting('buffers.shared_input')) {
+                return this.$state.ui.input_history;
+            }
+            return this.buffer.input_history;
+        },
+        history_pos: {
+            get() {
+                if (state.setting('buffers.shared_input')) {
+                    return this.$state.ui.input_history_pos;
+                }
+                return this.buffer.input_history_pos;
+            },
+            set(newVal) {
+                if (state.setting('buffers.shared_input')) {
+                    this.$state.ui.input_history_pos = newVal;
+                } else {
+                    this.buffer.input_history_pos = newVal;
+                }
+            },
         },
     },
     watch: {

--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -36,6 +36,8 @@ const stateObj = {
         is_narrow: false,
         favicon_counter: 0,
         current_input: '',
+        input_history: [],
+        input_history_pos: 0,
         show_advanced_tab: false,
     },
     networks: [],

--- a/src/libs/state/BufferState.js
+++ b/src/libs/state/BufferState.js
@@ -36,6 +36,8 @@ export default class BufferState {
         this.active_timeout = null;
         this.message_count = 0;
         this.current_input = '';
+        this.input_history = [];
+        this.input_history_pos = 0;
         this.show_input = true;
 
         Vue.observable(this);


### PR DESCRIPTION
this uses state if shared_input is true or buffer otherwise

closes #1051