### PR TITLE
optionally store nicklist scroll position and restore it after switching buffers

### DIFF
--- a/src/libs/state/BufferState.js
+++ b/src/libs/state/BufferState.js
@@ -35,6 +35,7 @@ export default class BufferState {
         this.last_read = 0;
         this.active_timeout = null;
         this.message_count = 0;
+        this.nicklist_index = 0;
         this.current_input = '';
         this.input_history = [];
         this.input_history_pos = 0;

--- a/src/res/configTemplates.js
+++ b/src/res/configTemplates.js
@@ -69,6 +69,7 @@ export const configTemplates = {
             default_ban_mask: '*!%i@%h',
             default_kick_reason: 'Your behaviour is not conducive to the desired environment.',
             shared_input: false,
+            store_nicklist_position: true,
             show_message_info: true,
             who_loop: true,
             share_typing: true,


### PR DESCRIPTION
this uses vue-virtual-scroller emitUpdate that comes with a warning below, the buffer setting does also disable this emitUpdate feature

`
emitUpdate (default: false): emit a 'update' event each time the virtual scroller content is updated (can impact performance).`

closes #1104