### PR TITLE
HOTFIX: Fixed the 'greetingText' multi-line spaces

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -368,7 +368,7 @@ body {
 
 .kiwi-wrap {
     font-size: 90%;
-    line-height: 1.6em;
+    line-height: 2.3em;
     font-family: Source Sans Pro, Helvetica, sans-serif;
     -webkit-font-smoothing: antialiased;
     height: 100%;


### PR DESCRIPTION
It now has more space between multi-lines, so now the text looking more pretty.