### PR TITLE
HOTFIX: Fixes the 'greetingText' multi-line spaces

### DIFF
--- a/src/components/startups/CommonLayout.vue
+++ b/src/components/startups/CommonLayout.vue
@@ -105,7 +105,7 @@ export default {
     color: #1b1b1b;
     font-size: 1.5em;
     padding: 2em;
-    line-height: 1.6em;
+    line-height: 2.3em;
 }
 
 @media (min-width: 850px) {


### PR DESCRIPTION
Startup screen now has more space between multi-lines, so now the text looking more pretty.