### PR TITLE
HOTFIX: Fixes the 'greetingText' multi-line spaces

### DIFF
--- a/src/components/startups/Welcome.vue
+++ b/src/components/startups/Welcome.vue
@@ -356,6 +356,7 @@ form.kiwi-welcome-simple-form h2 {
     font-weight: 600;
     font-size: 2.2em;
     text-align: center;
+    line-height: 1.2em;
 }
 
 .kiwi-welcome-simple-error {


### PR DESCRIPTION
Startup screen now has more space between multi-lines, so now the text looking more pretty. (last chance)