### PR TITLE
Fix sending messages on IE11 by polyfilling uint8 TypedArray

### DIFF
--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -27,6 +27,7 @@ module.exports = {
         'core-js/fn/promise', // required by the webpack runtime for async import(). babel polyfills don't help us here. ie11
         'core-js/fn/array/virtual/find-index', // required for vue-virtual-scroller & ie11
         'core-js/fn/array/virtual/includes', // required for vue-virtual-scroller & ie11
+        'core-js/fn/typed/uint8-array', // required for runes parsing in irc-framework & ie11
         './src/main.js'
     ]
   },


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/slice

used by the replacement for runes in irc-framework 4.4.0