### PR TITLE
Only use Intl.Collator in nicklist if its supported (fixes ios9)

### DIFF
--- a/src/components/Nicklist.vue
+++ b/src/components/Nicklist.vue
@@ -52,10 +52,25 @@ import NicklistUser from './NicklistUser';
 
 let log = Logger.namespace('Nicklist');
 
+// This provides a better sort for numbered nicks but does not work on ios9
+let intlCollator = null;
+if (global.Intl) {
+    intlCollator = new Intl.Collator({}, { numeric: true });
+}
+
 // Hot function, so it's here for easier caching
-let strComparison = new Intl.Collator({}, { numeric: true });
 function strCompare(a, b) {
-    return strComparison.compare(a, b);
+    if (intlCollator) {
+        return intlCollator.compare(a, b);
+    }
+
+    if (a === b) {
+        return 0;
+    }
+
+    return a > b ?
+        1 :
+        -1;
 }
 
 export default {


### PR DESCRIPTION
not sure if there is a neater way to do this, but it does appear to work (dont have ios device to test)

closes #1120