### PR TITLE
Dont show nicklist button highlighted when a user is viewed in the sidebar

### DIFF
--- a/src/components/ContainerHeader.vue
+++ b/src/components/ContainerHeader.vue
@@ -32,7 +32,6 @@
                 <div
                     :class="{
                         'kiwi-header-option--active': sidebarState.sidebarSection === 'nicklist'
-                            || sidebarState.sidebarSection === 'user'
                     }"
                     class="kiwi-header-option kiwi-header-option-nicklist"
                 >


### PR DESCRIPTION
this makes it clearer that none of the header buttons are currently active