### PR TITLE
Allow use of config-dev.json in the root folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ srcdocs/
 npm-debug.log
 test/unit/coverage
 src/res/locales/available.json
+static/config.local.json

--- a/build/webpack.dev.conf.js
+++ b/build/webpack.dev.conf.js
@@ -4,6 +4,7 @@ const webpack = require('webpack')
 const config = require('../config')
 const merge = require('webpack-merge')
 const path = require('path')
+const fs = require("fs")
 const baseWebpackConfig = require('./webpack.base.conf')
 const CopyWebpackPlugin = require('copy-webpack-plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
@@ -65,7 +66,7 @@ const devWebpackConfig = merge(baseWebpackConfig, {
       {
         from: path.resolve(__dirname, '../static'),
         to: config.dev.assetsSubDirectory,
-        ignore: ['.*']
+        ignore: ['.*', 'config.local.json']
       }
     ])
   ]
@@ -81,6 +82,20 @@ module.exports = new Promise((resolve, reject) => {
       process.env.PORT = port
       // add port to devServer config
       devWebpackConfig.devServer.port = port
+
+      // override config.json with config.local.json if it exists
+      let localConfig = path.resolve(__dirname, '../static/config.local.json');
+      if (fs.existsSync(localConfig)) {
+        devWebpackConfig.plugins.push(
+          new CopyWebpackPlugin([
+            {
+              from: localConfig,
+              to: config.dev.assetsSubDirectory + '/config.json',
+              force: true
+            }
+          ])
+        )
+      }
 
       // Add FriendlyErrorsPlugin
       devWebpackConfig.plugins.push(new FriendlyErrorsPlugin({

--- a/build/webpack.prod.conf.js
+++ b/build/webpack.prod.conf.js
@@ -117,7 +117,7 @@ const webpackConfig = merge(baseWebpackConfig, {
       {
         from: path.resolve(__dirname, '../static'),
         to: config.build.assetsSubDirectory,
-        ignore: ['.*']
+        ignore: ['.*', 'config.local.json']
       }
     ])
   ]


### PR DESCRIPTION
this will override `static/config.json` when running webpack dev server if `config-dev.json` is detected in the root dir

should help accidental commits of `static/config.json` and help devs avoid loosing their dev config when switching branches or performing `git reset` etc

it is also possible to maintain this behaviour in the vue-cli3 branch