### PR TITLE
Adds AM/PM to 12hr timestamps.

### DIFF
--- a/src/components/AppSettings.vue
+++ b/src/components/AppSettings.vue
@@ -260,7 +260,7 @@ export default {
             set: function set24Timestamps(newVal) {
                 let newFormat = newVal ?
                     '%H:%M:%S' :
-                    '%l:%M:%S';
+                    '%l:%M:%S %p';
                 state.setting('buffers.timestamp_format', newFormat);
             },
         },


### PR DESCRIPTION
Currently, timestamps in the 12hr format don't show AM/PM. This PR fixes that.

The timestamps become, e.g.:

`6:14:25 PM`
`2:00:13 AM`