### PR TITLE
Sends the previous password when clearing the channel password

### DIFF
--- a/src/components/ChannelInfo.vue
+++ b/src/components/ChannelInfo.vue
@@ -72,7 +72,7 @@ function generateComputedModeWithParam(mode) {
             if (newVal) {
                 this.setMode('+' + mode, newVal);
             } else {
-                this.setMode('-' + mode);
+                this.setMode('-' + mode, this.modeVal(mode));
             }
         },
     };


### PR DESCRIPTION
When clearing the channel password, sends the old password. Some servers require this format.

E.g.:

```
/mode #channel -k <old_password>
```