### PR TITLE
Adds `onceWithTimeout` function to state.

### DIFF
--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -869,7 +869,11 @@ const state = new Vue({
         },
 
         onceWithTimeout(event, eventCallback, timeoutCallback, timeout = 10000) {
-            const timeoutID = setTimeout(timeoutCallback, timeout);
+            const timeoutID = setTimeout(() => {
+                if (typeof timeoutCallback === 'function') {
+                    timeoutCallback();
+                }
+            }, timeout);
 
             this.$once(event, (...args) => {
                 clearTimeout(timeoutID);

--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -867,6 +867,15 @@ const state = new Vue({
         getStartups() {
             return availableStartups;
         },
+
+        onceWithTimeout(event, eventCallback, timeoutCallback, timeout = 10000) {
+            const timeoutID = setTimeout(timeoutCallback, timeout);
+
+            this.$once(event, (...args) => {
+                clearTimeout(timeoutID);
+                eventCallback(...args);
+            });
+        },
     },
 });
 


### PR DESCRIPTION
This PR adds a `onceWithTimeout` function to `state` that acts like `$once` but adds a timeout callback.

This is useful for instance when we send a command to the BOUNCER and need to wait for a confirmation. Adding a timeout makes it easier to deal with the case when the BOUNCER never replies for any reason.

Function:
```
onceWithTimeout(event, eventCallback, timeoutCallback, timeout = 10000)
```
Params:
- **event**: name of the event;
- **eventCallback**: callback for the event
- **timeoutCallback** _(optional)_: callback in case of timeout
- **timeout** _(optional, default = `10000`)_: timeout, 10 seconds by default

Example of usage:

```
this.state.onceWithTimeout(
    'irc.raw.DEVICE',
    (command, event) => {
      console.log(`Bouncer reply ${command} ${event.params[0]}`)
    },
    () => console.log(`Bouncer reply timeout!`)
);
```

I am not too sure about the function name. Thought about `$onceWithTimeout`, `timeoutOnce`, etc, but those seemed worse. Also not too sure about the default timeout. Is 10 seconds a sensible value or should be greater?