### PR TITLE
Adds the buffer flag is_requesting_chathistory.

### DIFF
--- a/src/libs/IrcClient.js
+++ b/src/libs/IrcClient.js
@@ -822,7 +822,7 @@ function clientMiddleware(state, network) {
                 if (correctBuffer && numConnects > 1) {
                     buffer.requestScrollback('forward');
                 } else if (correctBuffer) {
-                    network.ircClient.chathistory.before(buffer.name, '*');
+                    buffer.requestLatestScrollback();
                 }
             }
         }

--- a/src/libs/state/BufferState.js
+++ b/src/libs/state/BufferState.js
@@ -269,23 +269,23 @@ export default class BufferState {
         }
 
         let ircClient = this.getNetwork().ircClient;
-        this.flags.is_requesting_chathistory = true;
+        this.flag('is_requesting_chathistory', true);
         ircClient.chathistory[chathistoryFuncName](this.name, time).then((event) => {
             if (!event || event.commands.length === 0) {
-                this.flags.chathistory_available = false;
+                this.flag('chathistory_available', false);
             } else {
-                this.flags.chathistory_available = true;
+                this.flag('chathistory_available', true);
             }
         }).finally(() => {
-            this.flags.is_requesting_chathistory = false;
+            this.flag('is_requesting_chathistory', false);
         });
     }
 
     requestLatestScrollback() {
         let ircClient = this.getNetwork().ircClient;
-        this.flags.is_requesting_chathistory = true;
+        this.flag('is_requesting_chathistory', true);
         ircClient.chathistory.before(this.name, '*').finally(() => {
-            this.flags.is_requesting_chathistory = false;
+            this.flag('is_requesting_chathistory', false);
         });
     }
 

--- a/src/libs/state/BufferState.js
+++ b/src/libs/state/BufferState.js
@@ -29,6 +29,7 @@ export default class BufferState {
             chathistory_available: true,
             requested_modes: false,
             requested_banlist: false,
+            is_requesting_chathistory: false,
         };
         this.settings = { };
         this.last_read = 0;
@@ -268,12 +269,23 @@ export default class BufferState {
         }
 
         let ircClient = this.getNetwork().ircClient;
+        this.flags.is_requesting_chathistory = true;
         ircClient.chathistory[chathistoryFuncName](this.name, time).then((event) => {
             if (!event || event.commands.length === 0) {
                 this.flags.chathistory_available = false;
             } else {
                 this.flags.chathistory_available = true;
             }
+        }).finally(() => {
+            this.flags.is_requesting_chathistory = false;
+        });
+    }
+
+    requestLatestScrollback() {
+        let ircClient = this.getNetwork().ircClient;
+        this.flags.is_requesting_chathistory = true;
+        ircClient.chathistory.before(this.name, '*').finally(() => {
+            this.flags.is_requesting_chathistory = false;
         });
     }
 


### PR DESCRIPTION
This flag allows the UI to know that the buffer chat history is being loaded. That way, we can present the user a loader or some other indicator that something is happening in the background.