### PR TITLE
Add getLoadingState() function to BufferState.js

### DIFF
--- a/src/libs/IrcClient.js
+++ b/src/libs/IrcClient.js
@@ -802,7 +802,9 @@ function clientMiddleware(state, network) {
 
         if (command === 'userlist') {
             let buffer = state.getOrAddBufferByName(networkid, event.channel);
-            let hadExistingUsers = Object.keys(buffer.users).filter(u => u !== network.ircClient.user.nick).length > 0;
+            let hadExistingUsers = Object.keys(buffer.users)
+                .filter(u => u !== network.ircClient.user.nick)
+                .length > 0;
             let users = [];
             event.users.forEach((user) => {
                 users.push({

--- a/src/libs/IrcClient.js
+++ b/src/libs/IrcClient.js
@@ -730,18 +730,6 @@ function clientMiddleware(state, network) {
                 message: messageBody,
                 type: 'motd',
             });
-
-            let historySupport = !!network.ircClient.chathistory.isSupported();
-
-            // If this is a reconnect then request chathistory from our last position onwards
-            // to get any missed messages
-            if (numConnects > 1 && historySupport) {
-                network.buffers.forEach((b) => {
-                    if (b.isChannel() || b.isQuery()) {
-                        b.requestScrollback('forward');
-                    }
-                });
-            }
         }
 
         if (command === 'nick in use' && !client.connection.registered) {

--- a/src/libs/IrcClient.js
+++ b/src/libs/IrcClient.js
@@ -802,7 +802,7 @@ function clientMiddleware(state, network) {
 
         if (command === 'userlist') {
             let buffer = state.getOrAddBufferByName(networkid, event.channel);
-            let hadExistingUsers = Object.keys(buffer.users).length > 0;
+            let hadExistingUsers = Object.keys(buffer.users).filter(u => u !== network.ircClient.user.nick).length > 0;
             let users = [];
             event.users.forEach((user) => {
                 users.push({

--- a/src/libs/state/BufferState.js
+++ b/src/libs/state/BufferState.js
@@ -39,6 +39,9 @@ export default class BufferState {
         this.input_history = [];
         this.input_history_pos = 0;
         this.show_input = true;
+
+        // Counter for chathistory requests. While this value is 0, it means that this buffer is
+        // still loading messages
         this.chathistory_request_count = 0;
 
         Vue.observable(this);
@@ -63,12 +66,15 @@ export default class BufferState {
             maybeStartWhoLoop(this);
         }
 
+        // When the network re-connects, we reset the chathistory request counter.
+        // This will make the `getLoadingState()` stay as 'loading' while the chathistory reloads.
         function onNetworkConnecting(event) {
             if (event.network === this.getNetwork()) {
                 this.chathistory_request_count = 0;
             }
         }
 
+        // Clean up the previous event and itself when the buffer is closed.
         function onBufferClose(event) {
             if (event.buffer === this) {
                 this.state.$off('network.connecting', onNetworkConnectingBound);

--- a/src/libs/state/BufferState.js
+++ b/src/libs/state/BufferState.js
@@ -298,7 +298,7 @@ export default class BufferState {
         this.flag('is_requesting_chathistory', true);
         this.chathistory_request_count += 1;
         ircClient.chathistory[chathistoryFuncName](this.name, time)
-            .then(event => {
+            .then((event) => {
                 if (!event || event.commands.length === 0) {
                     this.flag('chathistory_available', false);
                 } else {
@@ -429,23 +429,23 @@ export default class BufferState {
 
     getLoadingState() {
         const networkState = this.getNetwork().state;
+        const historySupport = !!this.getNetwork().ircClient.chathistory.isSupported();
 
         if (networkState === 'disconnected') {
             return 'disconnected';
         } else if (networkState === 'connecting') {
             return 'connecting';
-        } else if (networkState === 'connected') {
-            if (
-                this.flags.is_requesting_chathistory ||
-                (this.chathistory_request_count === 0 &&
-                    this.joined &&
-                    this.enabled)
-            ) {
-                return 'loading';
-            } else {
-                return 'done';
-            }
+        } else if (
+            networkState === 'connected' &&
+            historySupport &&
+            this.joined &&
+            this.enabled &&
+            (this.flags.is_requesting_chathistory ||
+                this.chathistory_request_count === 0)
+        ) {
+            return 'loading';
         }
+        return 'done';
     }
 
     isReady() {

--- a/src/libs/state/BufferState.js
+++ b/src/libs/state/BufferState.js
@@ -419,7 +419,7 @@ export default class BufferState {
                     this.joined &&
                     this.enabled)
             ) {
-                return 'loadingMessages';
+                return 'loading';
             }
 
             return 'done';

--- a/src/libs/state/BufferState.js
+++ b/src/libs/state/BufferState.js
@@ -437,11 +437,15 @@ export default class BufferState {
             return 'connecting';
         } else if (
             networkState === 'connected' &&
-            historySupport &&
             this.joined &&
             this.enabled &&
-            (this.flags.is_requesting_chathistory ||
+            (
+                historySupport &&
+                (this.flags.is_requesting_chathistory ||
+                // If chathistory is supported then a request will always be made when first joining
+                // a channel. If request_count===0 then we're still waiting for it to happen.
                 this.chathistory_request_count === 0)
+            )
         ) {
             return 'loading';
         }


### PR DESCRIPTION
The buffer takes some time to load the chat history. We need a way to provide the UI with the information that the buffer is still loading those messages.

This PR adds the function `getLoadingState()` that returns one of the following states:

- `disconnected`: network is disconnected;
- `connecting`: network is connecting;
- `loading`: buffer is loading the chat history;
- `done`: buffer has finished loading and is now ready;

It adds also the function `isReady()` which just returns true if the LoadingState is `done`.