### PR TITLE
Keep BufferState in 'loading' state while processing the batch msgs

### DIFF
--- a/src/libs/batchedAdd.js
+++ b/src/libs/batchedAdd.js
@@ -13,8 +13,11 @@ export default function batchedAdd(singleFn, batchedFn) {
     function queueLoop() {
         numInLastSec = 0;
         if (queue.length) {
-            batchedFn(queue);
+            // emptying queue before calling batchedFn in case that function triggers
+            // code that needs to see that the queue has been processed.
+            let q = queue;
             queue = [];
+            batchedFn(q);
             numInLastSec = 0;
             setTimeout(queueLoop, loopInterval);
         } else {

--- a/src/libs/state/BufferState.js
+++ b/src/libs/state/BufferState.js
@@ -437,7 +437,8 @@ export default class BufferState {
         const networkState = this.getNetwork().state;
         const historySupport = !!this.getNetwork().ircClient.chathistory.isSupported();
         const messagesInBatchQueue = this.addMessageBatch.queue().length;
-        // triggers reactivity to update the state
+        // Hack; We need to make vue aware that we depend on message_count in order to
+        // update the loading state.
         // eslint-disable-next-line no-unused-vars
         const messageCount = this.message_count;
 

--- a/src/libs/state/BufferState.js
+++ b/src/libs/state/BufferState.js
@@ -436,6 +436,10 @@ export default class BufferState {
     getLoadingState() {
         const networkState = this.getNetwork().state;
         const historySupport = !!this.getNetwork().ircClient.chathistory.isSupported();
+        const messagesInBatchQueue = this.addMessageBatch.queue().length;
+        // triggers reactivity to update the state
+        // eslint-disable-next-line no-unused-vars
+        const messageCount = this.message_count;
 
         if (networkState === 'disconnected') {
             return 'disconnected';
@@ -448,9 +452,12 @@ export default class BufferState {
             (
                 historySupport &&
                 (this.flags.is_requesting_chathistory ||
-                // If chathistory is supported then a request will always be made when first joining
-                // a channel. If request_count===0 then we're still waiting for it to happen.
-                this.chathistory_request_count === 0)
+                    // If chathistory is supported then a request will always be made when first joining
+                    // a channel. If request_count===0 then we're still waiting for it to happen.
+                    this.chathistory_request_count === 0 ||
+                    // keep in loading state while the batch is being processed
+                    messagesInBatchQueue > 0
+                )
             )
         ) {
             return 'loading';

--- a/src/libs/state/BufferState.js
+++ b/src/libs/state/BufferState.js
@@ -452,8 +452,9 @@ export default class BufferState {
             (
                 historySupport &&
                 (this.flags.is_requesting_chathistory ||
-                    // If chathistory is supported then a request will always be made when first joining
-                    // a channel. If request_count===0 then we're still waiting for it to happen.
+                    // If chathistory is supported then a request will always be made when first
+                    // joining a channel. If request_count===0 then we're still waiting for it
+                    // to happen.
                     this.chathistory_request_count === 0 ||
                     // keep in loading state while the batch is being processed
                     messagesInBatchQueue > 0
@@ -510,8 +511,10 @@ function createMessageBatch(bufferState) {
                 bufferState.messagesObj.messageIds[msg.id] = msg;
             });
             trimMessages();
-            bufferState.message_count++;
         }
+        // Trigger Vue's reactivity on the buffer whether messages were added or not, just in case
+        // anything was depending on the batch queue which has now been emptied.
+        bufferState.message_count++;
     };
     let trimMessages = () => {
         let scrollbackSize = bufferState.setting('scrollback_size');


### PR DESCRIPTION
The previous implementation of `getLoadingState` in the BufferState was returning `done` as soon as the chat history request ended. The problem is that after the messages return they will very likely be batched (see `batchedAdd.js`). As a consequence, the state `done` does not indicate that the new messages are properly loaded in the buffer, which is very important for the UI side.

This PR fixes this situation by retrieving the number of messages in the `batchedAdd.js` queue. If there are messages in this queue, keep in the loading state.