### PR TITLE
Correct typo in code

### DIFF
--- a/src/components/startups/CommonLayout.vue
+++ b/src/components/startups/CommonLayout.vue
@@ -142,7 +142,7 @@ export default {
         transform: translateY(100%);
     }
 
-    .kiei-startup-common-section-connection {
+    .kiwi-startup-common-section-connection {
         padding-top: 2em;
     }
 


### PR DESCRIPTION
Correction of typo on #L145     .kiei-startup-common-section-connection { has been changed over to     .kiwi-startup-common-section-connection {