### PR TITLE
Removing cog icon in container header and link it inside info.

### DIFF
--- a/src/components/ContainerHeader.vue
+++ b/src/components/ContainerHeader.vue
@@ -47,19 +47,6 @@
                     </a>
                 </div>
                 <div
-                    :class="{
-                        'kiwi-header-option--active': sidebarState.sidebarSection === 'settings'
-                    }"
-                    class="kiwi-header-option kiwi-header-option-settings"
-                >
-                    <a
-                        :title="$t('channel_settings')"
-                        @click="sidebarState.toggleBufferSettings()"
-                    >
-                        <i class="fa fa-cog" aria-hidden="true"/>
-                    </a>
-                </div>
-                <div
                     v-if="sidebarState.isPinned"
                     class="kiwi-header-option kiwi-header-option-unpinsidebar"
                 >

--- a/src/components/SidebarAboutBuffer.vue
+++ b/src/components/SidebarAboutBuffer.vue
@@ -1,6 +1,12 @@
 <template>
     <div class="kiwi-aboutbuffer">
-        <h3>{{ b.name }}</h3>
+        <h3>
+            {{ b.name }}
+            <a :title="$t('channel_settings')"
+               @click="sidebarState.showBufferSettings()">
+                <i class="fa fa-cog" />
+            </a>
+        </h3>
 
         <div
             :class="{'kiwi-aboutbuffer-section--closed': closedSections.about}"
@@ -140,6 +146,15 @@ export default {
     padding: 10px;
     width: 100%;
     box-sizing: border-box;
+}
+
+.kiwi-aboutbuffer h3 a {
+    cursor: pointer;
+}
+
+.kiwi-aboutbuffer h3 i.fa {
+    float: right;
+    padding: 4px;
 }
 
 .kiwi-aboutbuffer-section {


### PR DESCRIPTION
Removing cog icon in container header to free space and make it less confusing with top-left cog icon. Now linking channel settings from info (i).