### PR TITLE
Allow plugins to set an avatar for a user

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "i18next-xhr-backend": "^1.4.1",
     "intersection-observer": "^0.7.0",
     "ip-regex": "2.1.0",
-    "irc-framework": "4.5.2",
+    "irc-framework": "4.6.0",
     "json-loader": "^0.5.4",
     "json5": "^2.1.0",
     "less": "^2.7.1",

--- a/src/components/Avatar.vue
+++ b/src/components/Avatar.vue
@@ -1,0 +1,65 @@
+<template>
+    <div
+        :style="avatarStyle"
+        :data-nick="message&&message.nick"
+        class="kiwi-avatar"
+    >
+        <span>{{ !avatar&&firstNickLetter || '' }}</span>
+    </div>
+</template>
+
+<script>
+
+'kiwi public';
+
+export default {
+    props: ['message', 'user', 'small'],
+    computed: {
+        avatar() {
+            return (this.message && this.message.avatar) || (this.user && this.user.avatar);
+        },
+        firstNickLetter() {
+            return ((this.message && this.message.nick) || (this.user && this.user.nick))[0];
+        },
+        avatarStyle() {
+            let style = '';
+            let avatar = this.avatar;
+            if (avatar) {
+                let url = avatar;
+                if (this.small) {
+                    url = url.replace(/\.jpg$/, '_small.jpg');
+                }
+                style = `background-image: url("${url}")`;
+            } else {
+                style = `background-color: ${this.colour};`;
+            }
+            return style;
+        },
+        colour() {
+            let user = (this.message && this.message.user) || this.user;
+            return user.getColour();
+        },
+    },
+};
+
+</script>
+
+<style>
+
+.kiwi-avatar {
+    text-transform: uppercase;
+    cursor: pointer;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    text-align: center;
+    line-height: 40px;
+    font-weight: 600;
+    margin-top: 3px;
+    border: 2px solid;
+    background-size: cover;
+    background-repeat: no-repeat;
+    background-position: center;
+}
+
+</style>

--- a/src/components/Avatar.vue
+++ b/src/components/Avatar.vue
@@ -1,10 +1,10 @@
 <template>
     <div
-        :style="avatarStyle"
         :data-nick="message&&message.nick"
+        :class="[hasAvatar ? 'kiwi-avatar--image' : '']"
         class="kiwi-avatar"
     >
-        <span>{{ !avatar&&firstNickLetter || '' }}</span>
+        <span :style="avatarStyle">{{ hasAvatar ?'' : firstNickLetter }}</span>
     </div>
 </template>
 
@@ -19,16 +19,21 @@ export default {
             return (this.message && this.message.avatar) || (this.user && this.user.avatar);
         },
         firstNickLetter() {
-            return ((this.message && this.message.nick) || (this.user && this.user.nick))[0];
+            return ((this.message && this.message.nick) || (this.user && this.user.nick) || '')[0];
+        },
+        hasAvatar() {
+            return !!(this.avatar && this.avatar.small);
         },
         avatarStyle() {
-            let style = '';
-            if (this.avatar && this.avatar.small) {
+            let style = {};
+
+            if (this.hasAvatar) {
                 let url = this.avatar.small;
-                style = `background-image: url("${url}")`;
+                style['background-image'] = `url("${url}")`;
             } else {
-                style = `background-color: ${this.colour};`;
+                style['background-color'] = `${this.colour}`;
             }
+
             return style;
         },
         colour() {
@@ -42,20 +47,28 @@ export default {
 
 <style>
 
-.kiwi-avatar {
+.kiwi-avatar > span {
     text-transform: uppercase;
     cursor: pointer;
-    width: 40px;
-    height: 40px;
+    width: 100%;
+    height: 100%;
     border-radius: 50%;
-    text-align: center;
-    line-height: 40px;
     font-weight: 600;
     margin-top: 3px;
     border: 2px solid;
     background-size: cover;
     background-repeat: no-repeat;
     background-position: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+}
+
+.kiwi-avatar--image > span {
+    border: none;
+
+    /* box-shadow: 0 0 3px 1px rgba(0, 0, 0, 0.5); */
 }
 
 </style>

--- a/src/components/Avatar.vue
+++ b/src/components/Avatar.vue
@@ -13,7 +13,7 @@
 'kiwi public';
 
 export default {
-    props: ['message', 'user', 'small'],
+    props: ['message', 'user'],
     computed: {
         avatar() {
             return (this.message && this.message.avatar) || (this.user && this.user.avatar);
@@ -23,12 +23,8 @@ export default {
         },
         avatarStyle() {
             let style = '';
-            let avatar = this.avatar;
-            if (avatar) {
-                let url = avatar;
-                if (this.small) {
-                    url = url.replace(/\.jpg$/, '_small.jpg');
-                }
+            if (this.avatar && this.avatar.small) {
+                let url = this.avatar.small;
                 style = `background-image: url("${url}")`;
             } else {
                 style = `background-color: ${this.colour};`;

--- a/src/components/MessageListAvatar.vue
+++ b/src/components/MessageListAvatar.vue
@@ -1,65 +1,16 @@
 <template>
-    <div
-        :style="avatarStyle"
-        :data-nick="message&&message.nick"
-        class="kiwi-messagelist-avatar"
-    >
-        <span>{{ !avatar&&firstNickLetter || '' }}</span>
-    </div>
+    <Avatar :user="user" :message="message" :small="small"/>
 </template>
 
 <script>
 
 'kiwi public';
 
+import Avatar from './Avatar';
+
 export default {
     props: ['message', 'user', 'small'],
-    computed: {
-        avatar() {
-            return (this.message && this.message.avatar) || (this.user && this.user.avatar);
-        },
-        firstNickLetter() {
-            return ((this.message && this.message.nick) || (this.user && this.user.nick))[0];
-        },
-        avatarStyle() {
-            let style = '';
-            let avatar = this.avatar;
-            if (avatar) {
-                let url = avatar;
-                if (this.small) {
-                    url = url.replace(/\.jpg$/, '_small.jpg');
-                }
-                style = `background-image: url("${url}")`;
-            } else {
-                style = `background-color: ${this.colour};`;
-            }
-            return style;
-        },
-        colour() {
-            let user = (this.message && this.message.user) || this.user;
-            return user.getColour();
-        },
-    },
+    components: {Avatar}
 };
 
 </script>
-
-<style>
-
-.kiwi-messagelist-avatar {
-    text-transform: uppercase;
-    cursor: pointer;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    text-align: center;
-    line-height: 40px;
-    font-weight: 600;
-    margin-top: 3px;
-    border: 2px solid;
-    background-size: cover;
-    background-repeat: no-repeat;
-    background-position: center;
-}
-
-</style>

--- a/src/components/MessageListAvatar.vue
+++ b/src/components/MessageListAvatar.vue
@@ -9,8 +9,8 @@
 import Avatar from './Avatar';
 
 export default {
+    components: { Avatar },
     props: ['message', 'user', 'small'],
-    components: {Avatar}
 };
 
 </script>

--- a/src/components/MessageListAvatar.vue
+++ b/src/components/MessageListAvatar.vue
@@ -1,12 +1,10 @@
 <template>
     <div
-        :style="{
-            'background-color': colour
-        }"
-        :data-nick="message.nick"
+        :style="avatarStyle"
+        :data-nick="message&&message.nick"
         class="kiwi-messagelist-avatar"
     >
-        {{ message.nick[0] }}
+        <span>{{ !avatar&&firstNickLetter || '' }}</span>
     </div>
 </template>
 
@@ -14,13 +12,31 @@
 
 'kiwi public';
 
+import state from '@/libs/state';
+
 export default {
-    props: ['message'],
+    props: ['message', 'user'],
     computed: {
+        avatar() {
+            return (this.message && this.message.avatar) || (this.user && this.user.avatar);
+        },
+        firstNickLetter() {
+            return ((this.message && this.message.nick) || (this.user && this.user.nick))[0];
+        },
+        avatarStyle() {
+            let style = '';
+            let avatar = this.avatar;
+            if (avatar) {
+                let url = avatar;
+                style = `background-image: url("${url}")`;
+            } else {
+                style = `background-color: ${this.colour};`;
+            }
+            return style;
+        },
         colour() {
-            return this.message.user ?
-                this.message.user.getColour() :
-                '';
+            let user = (this.message && this.message.user) || this.user;
+            return user.getColour();
         },
     },
 };
@@ -40,6 +56,9 @@ export default {
     font-weight: 600;
     margin-top: 3px;
     border: 2px solid;
+    background-size: cover;
+    background-repeat: no-repeat;
+    background-position: center;
 }
 
 </style>

--- a/src/components/MessageListAvatar.vue
+++ b/src/components/MessageListAvatar.vue
@@ -1,5 +1,5 @@
 <template>
-    <Avatar :user="user" :message="message" :small="small"/>
+    <Avatar :user="user" :message="message" />
 </template>
 
 <script>

--- a/src/components/MessageListAvatar.vue
+++ b/src/components/MessageListAvatar.vue
@@ -12,10 +12,8 @@
 
 'kiwi public';
 
-import state from '@/libs/state';
-
 export default {
-    props: ['message', 'user'],
+    props: ['message', 'user', 'small'],
     computed: {
         avatar() {
             return (this.message && this.message.avatar) || (this.user && this.user.avatar);
@@ -28,6 +26,9 @@ export default {
             let avatar = this.avatar;
             if (avatar) {
                 let url = avatar;
+                if (this.small) {
+                    url = url.replace(/\.jpg$/, '_small.jpg');
+                }
                 style = `background-image: url("${url}")`;
             } else {
                 style = `background-color: ${this.colour};`;

--- a/src/components/MessageListAvatar.vue
+++ b/src/components/MessageListAvatar.vue
@@ -10,7 +10,7 @@ import Avatar from './Avatar';
 
 export default {
     components: { Avatar },
-    props: ['message', 'user', 'small'],
+    props: ['message', 'user'],
 };
 
 </script>

--- a/src/components/MessageListMessageModern.vue
+++ b/src/components/MessageListMessageModern.vue
@@ -240,6 +240,11 @@ export default {
     position: absolute;
 }
 
+.kiwi-messagelist-message--modern .kiwi-avatar {
+    height: 40px;
+    width: 40px;
+}
+
 .kiwi-messagelist-message--modern.kiwi-messagelist-message--authorfirst.kiwi-messagelist-message-topic {
     padding: 10px 20px;
 }
@@ -278,7 +283,7 @@ export default {
     display: none;
 }
 
-.kiwi-messagelist-message--modern.kiwi-messagelist-message--authorrepeat .kiwi-messagelist-avatar {
+.kiwi-messagelist-message--modern.kiwi-messagelist-message--authorrepeat .kiwi-avatar {
     display: none;
 }
 
@@ -420,7 +425,7 @@ export default {
         display: none;
     }
 
-    .kiwi-messagelist-message--modern .kiwi-messagelist-avatar {
+    .kiwi-messagelist-message--modern .kiwi-avatar {
         display: none;
     }
 

--- a/src/components/MessageListMessageModern.vue
+++ b/src/components/MessageListMessageModern.vue
@@ -41,6 +41,7 @@
                 v-if="isMessage(message) && displayAvatar(message)"
                 :message="message"
                 :data-nick="message.nick"
+                :user="message.user"
             />
             <away-status-indicator
                 v-if="message.user && !isRepeat()"

--- a/src/components/Nicklist.vue
+++ b/src/components/Nicklist.vue
@@ -20,7 +20,7 @@
 
         <DynamicScroller
             :items="sortedUsers"
-            :min-item-size="26"
+            :min-item-size="34"
             :key-field="'nick'"
             class="kiwi-nicklist-users"
         >
@@ -288,6 +288,7 @@ export default {
     flex: 1 auto;
     list-style: none;
     line-height: 1.2em;
+    margin-top: 6px;
 }
 
 @media screen and (max-width: 759px) {

--- a/src/components/NicklistUser.vue
+++ b/src/components/NicklistUser.vue
@@ -60,10 +60,10 @@ export default {
 <style>
 
 .kiwi-nicklist-user {
-    line-height: 26px;
-    padding: 0 12px 0 12px;
+    line-height: 32px;
+    padding: 0 12px 6px 12px;
     border-left: 4px solid;
-    margin: 0;
+    margin: 0 0 0 0;
     position: relative;
     box-sizing: border-box;
     transition: all 0.1s;
@@ -95,6 +95,12 @@ export default {
     right: 1em;
     transition: all 0.2s;
     transition-delay: 0.1s;
+}
+
+li.kiwi-nicklist {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 4px;
 }
 
 .kiwi-avatar-container {

--- a/src/components/NicklistUser.vue
+++ b/src/components/NicklistUser.vue
@@ -10,7 +10,7 @@
         @click="nicklist.openUserbox(user)"
     >
         <div class="kiwi-avatar-container">
-            <Message-List-Avatar
+            <Avatar
                 v-if="user"
                 :user="user"
             />
@@ -37,13 +37,13 @@
 
 import AwayStatusIndicator from './AwayStatusIndicator';
 import TypingStatusIndicator from './TypingStatusIndicator';
-import MessageListAvatar from './MessageListAvatar';
+import Avatar from './Avatar';
 
 export default {
     components: {
         AwayStatusIndicator,
         TypingStatusIndicator,
-        MessageListAvatar,
+        Avatar,
     },
     props: ['network', 'user', 'nicklist'],
     computed: {
@@ -112,14 +112,14 @@ li.kiwi-nicklist {
     margin-right: 10px;
 }
 
-.kiwi-avatar-container .kiwi-messagelist-avatar {
+.kiwi-avatar-container .kiwi-avatar {
     width: 30px;
     height: 30px;
     border-radius: 50%;
     margin: 0;
 }
 
-.kiwi-avatar-container .kiwi-messagelist-avatar > span {
+.kiwi-avatar-container .kiwi-avatar > span {
     position: relative;
     top: -4px;
 }

--- a/src/components/NicklistUser.vue
+++ b/src/components/NicklistUser.vue
@@ -69,11 +69,14 @@ export default {
     transition: all 0.1s;
     cursor: pointer;
     white-space: nowrap;
+    display: flex;
+    align-items: center;
 }
 
 .kiwi-nicklist-user-nick {
     font-weight: bold;
     cursor: pointer;
+    flex: 1;
 }
 
 .kiwi-nicklist-messageuser {
@@ -97,31 +100,15 @@ export default {
     transition-delay: 0.1s;
 }
 
-li.kiwi-nicklist {
-    display: flex;
-    flex-direction: column;
-    margin-bottom: 4px;
-}
-
 .kiwi-avatar-container {
     position: relative;
-    display: inline-block;
-
-    /* Unless this element is floated left, the nick lineheight is broken */
-    float: left;
     margin-right: 10px;
+    flex: 0;
 }
 
 .kiwi-avatar-container .kiwi-avatar {
     width: 30px;
     height: 30px;
-    border-radius: 50%;
-    margin: 0;
-}
-
-.kiwi-avatar-container .kiwi-avatar > span {
-    position: relative;
-    top: -4px;
 }
 
 .kiwi-avatar-container .kiwi-awaystatusindicator {
@@ -129,6 +116,10 @@ li.kiwi-nicklist {
     top: 0;
     right: 0;
     margin: 0;
+}
+
+.kiwi-avatar-container-user-prefix {
+    flex: 0;
 }
 
 </style>

--- a/src/components/NicklistUser.vue
+++ b/src/components/NicklistUser.vue
@@ -9,11 +9,17 @@
         class="kiwi-nicklist-user"
         @click="nicklist.openUserbox(user)"
     >
-        <away-status-indicator
-            :network="network"
-            :user="user"
-            :toggle="false"
-        />
+        <div class="kiwi-avatar-container">
+            <Message-List-Avatar
+                v-if="user"
+                :user="user"
+            />
+            <away-status-indicator
+                :network="network"
+                :user="user"
+                :toggle="false"
+            />
+        </div>
         <span class="kiwi-nicklist-user-prefix">{{ nicklist.userModePrefix(user) }}</span><span
             :style="{ 'color': userColour }"
             class="kiwi-nicklist-user-nick"
@@ -31,11 +37,13 @@
 
 import AwayStatusIndicator from './AwayStatusIndicator';
 import TypingStatusIndicator from './TypingStatusIndicator';
+import MessageListAvatar from './MessageListAvatar';
 
 export default {
     components: {
         AwayStatusIndicator,
         TypingStatusIndicator,
+        MessageListAvatar,
     },
     props: ['network', 'user', 'nicklist'],
     computed: {
@@ -87,6 +95,34 @@ export default {
     right: 1em;
     transition: all 0.2s;
     transition-delay: 0.1s;
+}
+
+.kiwi-avatar-container {
+    position: relative;
+    display: inline-block;
+
+    /* Unless this element is floated left, the nick lineheight is broken */
+    float: left;
+    margin-right: 10px;
+}
+
+.kiwi-avatar-container .kiwi-messagelist-avatar {
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    margin: 0;
+}
+
+.kiwi-avatar-container .kiwi-messagelist-avatar > span {
+    position: relative;
+    top: -4px;
+}
+
+.kiwi-avatar-container .kiwi-awaystatusindicator {
+    position: absolute;
+    top: 0;
+    right: 0;
+    margin: 0;
 }
 
 </style>

--- a/src/components/NicklistUser.vue
+++ b/src/components/NicklistUser.vue
@@ -61,7 +61,7 @@ export default {
             return '';
         },
         shouldShowAvatars() {
-            return this.$state.setting('buffers.nicklist_avatars');
+            return this.nicklist.buffer.setting('nicklist_avatars');
         },
     },
 };

--- a/src/components/NicklistUser.vue
+++ b/src/components/NicklistUser.vue
@@ -9,11 +9,18 @@
         class="kiwi-nicklist-user"
         @click="nicklist.openUserbox(user)"
     >
-        <div class="kiwi-avatar-container">
+        <div v-if="shouldShowAvatars" class="kiwi-avatar-container">
             <Avatar
                 v-if="user"
                 :user="user"
             />
+            <away-status-indicator
+                :network="network"
+                :user="user"
+                :toggle="false"
+            />
+        </div>
+        <div v-else>
             <away-status-indicator
                 :network="network"
                 :user="user"
@@ -52,6 +59,9 @@ export default {
                 return this.user.getColour();
             }
             return '';
+        },
+        shouldShowAvatars() {
+            return this.$state.setting('buffers.nicklist_avatars');
         },
     },
 };

--- a/src/libs/state/UserState.js
+++ b/src/libs/state/UserState.js
@@ -17,7 +17,7 @@ export default class UserState {
         this.buffers = Object.create(null);
         this.hasWhois = false;
         this.typingState = Object.create(null);
-        this.avatar = user.avatar || '';
+        this.avatar = user.avatar || { small: '', large: '' };
         this.ignore = false;
 
         Vue.observable(this);

--- a/src/libs/state/UserState.js
+++ b/src/libs/state/UserState.js
@@ -17,6 +17,7 @@ export default class UserState {
         this.buffers = Object.create(null);
         this.hasWhois = false;
         this.typingState = Object.create(null);
+        this.avatar = user.avatar || '';
         this.ignore = false;
 
         Vue.observable(this);

--- a/src/res/configTemplates.js
+++ b/src/res/configTemplates.js
@@ -74,6 +74,7 @@ export const configTemplates = {
             share_typing: true,
             // flash_title: message/highlight/off
             flash_title: 'message',
+            nicklist_avatars: false,
         },
         // Startup screen default
         startupOptions: {

--- a/static/themes/common/base.css
+++ b/static/themes/common/base.css
@@ -878,7 +878,7 @@
 }
 
 /* ---- Modern Layout Styling ---- */
-.kiwi-messagelist-avatar {
+.kiwi-avatar {
     background-color: var(--brand-default-fg);
     color: var(--brand-default-bg);
     border-color: var(--brand-primary);

--- a/static/themes/common/base.css
+++ b/static/themes/common/base.css
@@ -842,7 +842,7 @@
 /* Traditional message styling hover */
 .kiwi-messagelist-message--compact .kiwi-messagelist-message-privmsg:hover,
 .kiwi-messagelist-message--compact .kiwi-messagelist-message-action:hover,
-.kiwi-messagelist-message--compact .kiwi-messagelist-message-notice:hover, {
+.kiwi-messagelist-message--compact .kiwi-messagelist-message-notice:hover {
     border-left-color: var(--brand-primary-hover);
 }
 
@@ -878,7 +878,7 @@
 }
 
 /* ---- Modern Layout Styling ---- */
-.kiwi-avatar {
+.kiwi-avatar > span {
     background-color: var(--brand-default-fg);
     color: var(--brand-default-bg);
     border-color: var(--brand-primary);

--- a/static/themes/dark/theme.css
+++ b/static/themes/dark/theme.css
@@ -122,7 +122,7 @@ button.u-button.u-button-primary.u-submit.kiwi-welcome-znc-start {
     color: #fff;
 }
 
-.kiwi-messagelist-avatar {
+.kiwi-avatar {
     background-color: var(--brand-default-bg);
     color: var(--brand-default-fg);
 }

--- a/static/themes/dark/theme.css
+++ b/static/themes/dark/theme.css
@@ -122,7 +122,7 @@ button.u-button.u-button-primary.u-submit.kiwi-welcome-znc-start {
     color: #fff;
 }
 
-.kiwi-avatar {
+.kiwi-avatar > span {
     background-color: var(--brand-default-bg);
     color: var(--brand-default-fg);
 }

--- a/static/themes/nightswatch/theme.css
+++ b/static/themes/nightswatch/theme.css
@@ -221,7 +221,7 @@
     border-left-color: var(--brand-midtone);
 }
 
-.kiwi-avatar {
+.kiwi-avatar > span {
     background-color: var(--brand-default-bg);
     color: var(--brand-default-fg);
 }

--- a/static/themes/nightswatch/theme.css
+++ b/static/themes/nightswatch/theme.css
@@ -221,7 +221,7 @@
     border-left-color: var(--brand-midtone);
 }
 
-.kiwi-messagelist-avatar {
+.kiwi-avatar {
     background-color: var(--brand-default-bg);
     color: var(--brand-default-fg);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3977,10 +3977,10 @@ ipaddr.js@1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.5.2.tgz#d4b505bde9946987ccf0fc58d9010ff9607e3fa0"
 
-irc-framework@4.5.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/irc-framework/-/irc-framework-4.5.2.tgz#ed370dcb1dae8e32e3d3badfbd85e7e312cae9a0"
-  integrity sha512-Z1VWx+ajkxFTMN3Kzv+rqEDWzuprFhrXzqRrAPRurm8mO153uVwRA3idxQ1+a0DxECpGhlvaGxPthV6Gl436gQ==
+irc-framework@4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/irc-framework/-/irc-framework-4.6.0.tgz#45846be58a3a97fc7b0610da380dfeed0fb99147"
+  integrity sha512-I/5QLe5BfK/4bgDRAaVec9l+8VYVEHOPYvjcNV5SshgCPssrFwjgCJ48oDYFf8J3HMAIbGTjqV+aOXCM/3r30A==
   dependencies:
     core-js "^3.0.1"
     eventemitter3 "^2.0.2"


### PR DESCRIPTION
(edit ~prawnsalad) For anyone that reads this in future, this PR now allows you to set `user.avatar.small='https://site.com/user/png'` to set a users avatar. It will be shown next to the users emssages in the Modern message layout, and if `buffers.nicklist_avatars` config option is set to `true` then it will also show in the nicklist.