### PR TITLE
Safeguards repeated chathistory replies.

### DIFF
--- a/src/libs/state/BufferState.js
+++ b/src/libs/state/BufferState.js
@@ -329,9 +329,13 @@ export default class BufferState {
                     return;
                 }
 
+                // The BNC server may reply with messages that are already in the buffer.
+                // This var stores whether there are new messages in the chathistory response.
                 let hasNewMessages = event.commands.some(msg =>
                     msg.tags.msgid && !this.messagesObj.messageIds[msg.tags.msgid]);
 
+                // If there are new messages, then there could be more in the backlog.
+                // If there are no new messages, then the chat history is empty.
                 this.flag('chathistory_available', hasNewMessages);
             })
             .finally(() => {

--- a/src/libs/state/BufferState.js
+++ b/src/libs/state/BufferState.js
@@ -324,11 +324,15 @@ export default class BufferState {
         this.chathistory_request_count += 1;
         ircClient.chathistory[chathistoryFuncName](this.name, time)
             .then((event) => {
-                if (!event || event.commands.length === 0) {
+                if (!event) {
                     this.flag('chathistory_available', false);
-                } else {
-                    this.flag('chathistory_available', true);
+                    return;
                 }
+
+                let hasNewMessages = event.commands.some(msg =>
+                    msg.tags.msgid && !this.messagesObj.messageIds[msg.tags.msgid]);
+
+                this.flag('chathistory_available', hasNewMessages);
             })
             .finally(() => {
                 this.flag('is_requesting_chathistory', false);


### PR DESCRIPTION
**Problem:**
When the bnc replies with repeated messages in the chat history, the app fails to set the buffer `chathistory_available` tag to false, and so the app always thinks there is something to retrieve.

This is fundamentally a BNC bug, but it may be worth it to make a failsafe in the app.

**Solution:**
Checks if any message retrieved from chathistory is really new (by ID).