### PR TITLE
Set sidebarSection = '' when a plugin sets a sidebar component

### DIFF
--- a/src/components/SidebarState.vue
+++ b/src/components/SidebarState.vue
@@ -27,6 +27,7 @@ export default Vue.extend({
     created() {
         this.listen(this.$state, 'sidebar.component', (component) => {
             this.activeComponent = component;
+            this.sidebarSection = '';
         });
 
         // Allow forcing the sidebar open at startup


### PR DESCRIPTION
Currently when a plugin sets the sidebar component the sidebar state will behave like another component is selected