### PR TITLE
Remove Message in buffer when traffic_as_activity is disabled

### DIFF
--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -539,8 +539,6 @@ const state = new Vue({
                 bufferMessage.ignore = true;
             }
 
-            buffer.addMessage(bufferMessage);
-
             // Increment the unread counter if this buffer is not active
             let includeAsActivity = false;
             let typesForActivty = ['privmsg', 'action', 'notice', 'wallops'];
@@ -550,6 +548,10 @@ const state = new Vue({
 
             if (typesForActivty.indexOf(message.type) > -1) {
                 includeAsActivity = true;
+            }
+
+            if (includeAsActivity) {
+                buffer.addMessage(bufferMessage);
             }
 
             let isActiveBuffer = (


### PR DESCRIPTION
Steps to reproduce

Use this settings:

```
"show_joinparts": false
"scrollback_size": 20, //set a low value to test more easy
```

When you join in a channel with high traffic data (join/part) more than privmsg messages this settings causes a bug. Traffic data consumes all buffer and the user only see a few messages.


We can use the setting 'traffic_as_activity' to avoid this behavior, and send to the buffer only when is necessary.

Thanks.

