### PR TITLE
Adding realname (if enabled) in join, part and quit messages

### DIFF
--- a/src/helpers/TextFormatting.js
+++ b/src/helpers/TextFormatting.js
@@ -135,6 +135,26 @@ export function formatUser(fNick) {
 }
 
 /**
+ * Create a user reference string similar to 'nick (realname)'
+ */
+export function formatUserWithRealname(fNick, fRealname) {
+    let nick = '';
+    let realname = '';
+
+    // Allow passing of a user object or irc-framework event
+    if (typeof fNick === 'object') {
+        let user = fNick;
+        nick = user.nick;
+        realname = user.gecos;
+    } else {
+        nick = fNick;
+        realname = fRealname;
+    }
+
+    return formatText('user_with_realname', { nick, realname });
+}
+
+/**
  * Create a full user reference similar to 'nick (user@host)'
  */
 export function formatUserFull(fNick, fUsername, fHost) {
@@ -155,6 +175,37 @@ export function formatUserFull(fNick, fUsername, fHost) {
     }
 
     return formatText('user_full', { nick, username, host });
+}
+
+/**
+ * Create a full user reference similar to 'nick (user@host) (realname)'
+ */
+export function formatUserFullWithRealname(fNick, fUsername, fHost, fRealname) {
+    let nick = '';
+    let username = '';
+    let host = '';
+    let realname = '';
+
+    // Allow passing of a user object or irc-framework event
+    if (typeof fNick === 'object') {
+        let user = fNick;
+        nick = user.nick;
+        username = user.username || user.ident;
+        host = user.hostname || user.host;
+        realname = user.gecos;
+    } else {
+        nick = fNick;
+        username = fUsername;
+        host = fHost;
+        realname = fRealname;
+    }
+
+    return formatText('user_full_with_realname', {
+        nick,
+        username,
+        host,
+        realname,
+    });
 }
 
 /**

--- a/src/libs/IrcClient.js
+++ b/src/libs/IrcClient.js
@@ -496,9 +496,14 @@ function clientMiddleware(state, network) {
                 network.ircClient.who(event.channel);
             }
 
-            let nick = buffer.setting('show_hostnames') ?
-                TextFormatting.formatUserFull(event) :
-                TextFormatting.formatUser(event);
+            let nick = TextFormatting.formatUser(event);
+            if (buffer.setting('show_hostnames') && buffer.setting('show_realnames')) {
+                nick = TextFormatting.formatUserFullWithRealname(event);
+            } else if (buffer.setting('show_hostnames')) {
+                nick = TextFormatting.formatUserFull(event);
+            } else if (buffer.setting('show_realnames')) {
+                nick = TextFormatting.formatUserWithRealname(event);
+            }
 
             let messageBody = TextFormatting.formatAndT(
                 'channel_join',
@@ -576,9 +581,14 @@ function clientMiddleware(state, network) {
                 });
             }
 
-            let nick = buffer.setting('show_hostnames') ?
-                TextFormatting.formatUserFull(event) :
-                TextFormatting.formatUser(event);
+            let nick = TextFormatting.formatUser(event);
+            if (buffer.setting('show_hostnames') && buffer.setting('show_realnames')) {
+                nick = TextFormatting.formatUserFullWithRealname(event);
+            } else if (buffer.setting('show_hostnames')) {
+                nick = TextFormatting.formatUserFull(event);
+            } else if (buffer.setting('show_realnames')) {
+                nick = TextFormatting.formatUserWithRealname(event);
+            }
 
             let messageBody = TextFormatting.formatAndT(
                 'channel_part',
@@ -608,9 +618,14 @@ function clientMiddleware(state, network) {
                     buffer.clearUsers();
                 }
 
-                let nick = buffer.setting('show_hostnames') ?
-                    TextFormatting.formatUserFull(event) :
-                    TextFormatting.formatUser(event);
+                let nick = TextFormatting.formatUser(event);
+                if (buffer.setting('show_hostnames') && buffer.setting('show_realnames')) {
+                    nick = TextFormatting.formatUserFullWithRealname(event);
+                } else if (buffer.setting('show_hostnames')) {
+                    nick = TextFormatting.formatUserFull(event);
+                } else if (buffer.setting('show_realnames')) {
+                    nick = TextFormatting.formatUserWithRealname(event);
+                }
 
                 let messageBody = TextFormatting.formatAndT(
                     'channel_quit',

--- a/src/res/configTemplates.js
+++ b/src/res/configTemplates.js
@@ -256,7 +256,9 @@ export const configTemplates = {
         emojiLocation: 'https://kiwiirc.com/shared/emoji/',
         textFormats: {
             user: '%nick',
+            user_with_realname: '%nick (%realname)',
             user_full: '%nick (%username@%host)',
+            user_full_with_realname: '%nick (%username@%host) (%realname)',
             channel_join: '→ %text',
             channel_part: '← %text (%reason)',
             channel_quit: '← %text (%reason)',


### PR DESCRIPTION
It makes sense that if user has show_realnames enabled, to shot it also in join, part and quit messages.

It has been combined with option of show_hostnames, adding two new formatting functions: formatUserWithRealname and formatUserFullWithRealname.

So now we have 4 options:

- Only nick (show_hostnames and show_realnames disabled): %nick
- Nick with mask (show_hostnames enabled): %nick (%username@%host)
- Nick with realname (show_realnames enabled): %nick (%realname)
- Nick with mask and realname (show_hostnames and show_realnames enabled): %nick (%username@%host) (%realname)