### PR TITLE
[API] MediaViewer fixes and improvements

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -36,6 +36,7 @@
                             <media-viewer
                                 :url="mediaviewerUrl"
                                 :component="mediaviewerComponent"
+                                :component-props="mediaviewerComponentProps"
                                 :is-iframe="mediaviewerIframe"
                                 class="kiwi-main-mediaviewer"
                                 @close="$state.$emit('mediaviewer.hide', { source: 'user' });"
@@ -108,6 +109,7 @@ export default {
             mediaviewerOpen: false,
             mediaviewerUrl: '',
             mediaviewerComponent: null,
+            mediaviewerComponentProps: {},
             mediaviewerIframe: false,
             themeUrl: '',
             sidebarState: new SidebarState(),
@@ -238,6 +240,7 @@ export default {
 
                 this.mediaviewerUrl = opts.url;
                 this.mediaviewerComponent = opts.component;
+                this.mediaviewerComponentProps = opts.componentProps;
                 this.mediaviewerIframe = opts.iframe;
                 this.mediaviewerOpen = true;
             });

--- a/src/components/MediaViewer.vue
+++ b/src/components/MediaViewer.vue
@@ -38,39 +38,37 @@
 <script>
 'kiwi public';
 
-import state from '@/libs/state';
-
 let embedlyTagIncluded = false;
 
 export default {
     props: ['url', 'component', 'componentProps', 'isIframe', 'showPin'],
-    data: function data() {
+    data() {
         return {
         };
     },
     computed: {
-        embedlyKey: function embedlyKey() {
-            return state.settings.embedly.key;
+        embedlyKey() {
+            return this.$state.settings.embedly.key;
         },
     },
     watch: {
-        url: function watchUrl() {
+        url() {
             this.updateEmbed();
         },
-        isIframe: function watchUrl() {
+        isIframe() {
             this.updateEmbed();
         },
     },
-    created: function created() {
+    created() {
         this.updateEmbed();
     },
-    mounted: function mounted() {
+    mounted() {
         this.$nextTick(() => {
-            state.$emit('mediaviewer.opened');
+            this.$state.$emit('mediaviewer.opened');
         });
     },
     methods: {
-        updateEmbed: function updateEmbed() {
+        updateEmbed() {
             if (!this.url || this.isIframe || this.component) {
                 // return if embedly script is not needed
                 return;

--- a/src/components/MediaViewer.vue
+++ b/src/components/MediaViewer.vue
@@ -15,15 +15,14 @@
                 <i class="fa fa-window-close" aria-hidden="true" />
             </a>
         </div>
-        <div :key="url">
-            <iframe
-                v-if="isIframe"
-                :src="url"
-                class="kiwi-mediaviewer-iframe"
-            />
-            <component :is="component" v-else-if="component" />
+        <iframe
+            v-if="isIframe"
+            :src="url"
+            class="kiwi-mediaviewer-iframe"
+        />
+        <component v-else-if="component" :is="component" :component-props="componentProps"/>
+        <div v-else :key="url" class="kiwi-mediaviewer-embedly">
             <a
-                v-else
                 ref="embedlyLink"
                 :href="url"
                 :data-card-key="embedlyKey"
@@ -44,7 +43,7 @@ import state from '@/libs/state';
 let embedlyTagIncluded = false;
 
 export default {
-    props: ['url', 'component', 'isIframe', 'showPin'],
+    props: ['url', 'component', 'componentProps', 'isIframe', 'showPin'],
     data: function data() {
         return {
         };
@@ -72,11 +71,12 @@ export default {
     },
     methods: {
         updateEmbed: function updateEmbed() {
-            let checkEmbedlyAndShowCard = () => {
-                if (this.isIframe) {
-                    return;
-                }
+            if (!this.url || this.isIframe || this.component) {
+                // return if embedly script is not needed
+                return;
+            }
 
+            let checkEmbedlyAndShowCard = () => {
                 // If the embedly function doesn't exist it's probably still loading
                 // the embedly script
                 if (typeof window.embedly !== 'function') {


### PR DESCRIPTION
this pr achieves a few things:

- Allows props to be passed with a component

- Allows plugins to better control the mediaviewer height (by not having component/iframe in a extra div)

- Stops the loading of embedly script when a component/iframe is used

- Fixes switching from embedly to a component/iframe without closing the mediaviewer

- Updates MediaViewer.vue to more modern code style