### PR TITLE
Don't start drawing LoadingAnimation if the component is being destroyed.

### DIFF
--- a/src/components/LoadingAnimation.vue
+++ b/src/components/LoadingAnimation.vue
@@ -21,6 +21,7 @@ export default {
             font: 'bold ' + 72 + 'px verdana',
             text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce eu arcu ipsum. ',
             animationFrame: null,
+            destroying: false,
         };
     },
     mounted() {
@@ -36,10 +37,15 @@ export default {
             this.Y.push(i * this.fontSize - 1600);
         }
         this.logo.onload = () => {
+            if (this.destroying) {
+                // the component has already been destroyed, we nolonger need the animation
+                return;
+            }
             this.draw();
         };
     },
-    destroyed() {
+    beforeDestroy() {
+        this.destroying = true;
         cancelAnimationFrame(this.animationFrame);
     },
     methods: {


### PR DESCRIPTION
to reproduce this /quit then reconnect. if you record performance you will see that its calling draw().

Its happening because the component is destroyed before the logo.onload has been called.