### PR TITLE
Fix typing indicators

### DIFF
--- a/src/components/MessageListMessageModern.vue
+++ b/src/components/MessageListMessageModern.vue
@@ -48,16 +48,10 @@
             <component
                 :is="injections.components.AwayStatusIndicator"
                 v-if="props.message.user && !props.m().isRepeat()"
-                :network="props.m().getNetwork()" :user="props.message.user"
-                :toggle="false"
-                class="kiwi-messagelist-awaystatus"
-            />
-            <component
-                :is="injections.components.TypingStatusIndicator"
-                v-if="props.message.user"
                 :network="props.m().getNetwork()"
                 :user="props.message.user"
-                class="kiwi-messagelist-typingstatus"
+                :toggle="false"
+                class="kiwi-messagelist-awaystatus"
             />
 
         </div>
@@ -143,7 +137,6 @@ import { urlRegex } from '@/helpers/TextFormatting';
 import MessageInfo from './MessageInfo';
 import MessageListAvatar from './MessageListAvatar';
 import AwayStatusIndicator from './AwayStatusIndicator';
-import TypingStatusIndicator from './TypingStatusIndicator';
 import MediaViewer from './MediaViewer';
 
 const methods = {
@@ -234,7 +227,6 @@ export default {
                 MessageAvatar: MessageListAvatar,
                 MessageInfo,
                 AwayStatusIndicator,
-                TypingStatusIndicator,
                 MediaViewer,
             },
         },

--- a/src/libs/state/UserState.js
+++ b/src/libs/state/UserState.js
@@ -52,11 +52,6 @@ export default class UserState {
 
     typingStatus(_target, status) {
         let target = _target.toLowerCase();
-        if (!this.typingState[target]) {
-            return { status: '' };
-            // Vue.set(this.typingState, target.toLowerCase(), { started: 0, status: '' });
-        }
-
         if (!status) {
             return this.typingState[target] || { status: '' };
         }


### PR DESCRIPTION
Fixes typingStatus() in UserState.js It was always returning status ''

Removed TypingStatusIndicator from MessageList Modern as its never worked and seems redundant.
It was being passed network as a prop when it needed buffer and fixing it caused more style issues.