### PR TITLE
disable parent window scroll when kiwiirc used inside iframe

### DIFF
--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -450,7 +450,7 @@ export default {
                 return;
             }
             if (this.$state.setting('enable_parent_scroll')) {
-                    this.$refs.ender.scrollIntoView(false);
+                this.$refs.ender.scrollIntoView(false);
             }
         },
         maybeScrollToBottom() {

--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -449,7 +449,9 @@ export default {
                 this.$el.scrollTop = this.$el.scrollHeight;
                 return;
             }
-            this.$refs.ender.scrollIntoView(false);
+            if (this.$state.setting('enable_parent_scroll')) {
+                    this.$refs.ender.scrollIntoView(false);
+            }
         },
         maybeScrollToBottom() {
             if (!this.maybeScrollToBottom_throttled) {

--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -233,6 +233,9 @@ export default {
         isIos() {
             return !!navigator.platform && /iPad|iPhone|iPod/.test(navigator.platform);
         },
+        isIframe() {
+            return !(window.parent === window) && this.$state.setting('disable_parent_scroll');
+        },
     },
     watch: {
         buffer(newBuffer) {
@@ -443,15 +446,16 @@ export default {
             }
         },
         scrollToBottom() {
-            if (this.isIos) {
+            if (this.isIos || this.isIframe) {
                 // On iOS using scrollIntoView causes issues with the keyboard pushing
                 // the view upwards resulting in the input box being behind the keyboard
+                //
+                // when inside iframe, scrollIntoView() also scrolls parent window
+
                 this.$el.scrollTop = this.$el.scrollHeight;
                 return;
             }
-            if (this.$state.setting('enable_parent_scroll')) {
-                this.$refs.ender.scrollIntoView(false);
-            }
+            this.$refs.ender.scrollIntoView(false);
         },
         maybeScrollToBottom() {
             if (!this.maybeScrollToBottom_throttled) {

--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -234,7 +234,7 @@ export default {
             return !!navigator.platform && /iPad|iPhone|iPod/.test(navigator.platform);
         },
         isIframe() {
-            return !(window.parent === window) && this.$state.setting('disable_parent_scroll');
+            return window !== window.parent;
         },
     },
     watch: {

--- a/src/res/configTemplates.js
+++ b/src/res/configTemplates.js
@@ -323,7 +323,6 @@ export const configTemplates = {
             general_error: '%text',
         },
         presetNetworks: [],
-        disable_parent_scroll: false,
     },
 
     // Config template for those hardcore irc veterans

--- a/src/res/configTemplates.js
+++ b/src/res/configTemplates.js
@@ -323,7 +323,7 @@ export const configTemplates = {
             general_error: '%text',
         },
         presetNetworks: [],
-        enable_parent_scroll: true,
+        disable_parent_scroll: false,
     },
 
     // Config template for those hardcore irc veterans

--- a/src/res/configTemplates.js
+++ b/src/res/configTemplates.js
@@ -323,6 +323,7 @@ export const configTemplates = {
             general_error: '%text',
         },
         presetNetworks: [],
+        enable_parent_scroll: true,
     },
 
     // Config template for those hardcore irc veterans


### PR DESCRIPTION
when kiwiirc used inside iframe, the parent window jumps into kiwiirc iframe everytime there is new message in kiwiirc. This patch disables jumping.