### PR TITLE
Make message senders nick double clickable

### DIFF
--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -381,9 +381,11 @@ export default {
 
             let network = this.buffer.getNetwork();
             let user = network.userByName(dataNick);
-            if (user && user.nick) {
-                this.$state.$emit('input.insertnick', user.nick);
-            }
+            // The user might have left use dataNick as fallback
+            let nick = (user && user.nick) ?
+                user.nick :
+                dataNick;
+            this.$state.$emit('input.insertnick', nick);
         },
         onMessageClick(event, message, delay) {
             // Delaying the click for 200ms allows us to check for a second click. ie. double click

--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -374,9 +374,15 @@ export default {
         onMessageDblClick(event, message) {
             clearTimeout(this.messageClickTmr);
 
-            let userNick = event.target.getAttribute('data-nick');
-            if (userNick) {
-                this.$state.$emit('input.insertnick', userNick);
+            let dataNick = event.target.getAttribute('data-nick');
+            if (!dataNick) {
+                return;
+            }
+
+            let network = this.buffer.getNetwork();
+            let user = network.userByName(dataNick);
+            if (user && user.nick) {
+                this.$state.$emit('input.insertnick', user.nick);
             }
         },
         onMessageClick(event, message, delay) {

--- a/src/components/MessageListMessageCompact.vue
+++ b/src/components/MessageListMessageCompact.vue
@@ -34,7 +34,8 @@
         :data-message-id="props.message.id"
         :data-nick="(props.message.nick||'').toLowerCase()"
         class="kiwi-messagelist-message kiwi-messagelist-message--compact"
-        @click="props.ml.onMessageClick($event, props.message)"
+        @click="props.ml.onMessageClick($event, props.message, true)"
+        @dblclick="props.ml.onMessageDblClick($event, props.message)"
     >
         <div
             v-if="props.ml.bufferSetting('show_timestamps')"
@@ -43,7 +44,7 @@
         >
             {{ props.ml.formatTime(props.message.time) }}
         </div>
-        <div
+        <a
             :style="{ 'color': props.ml.userColour(props.message.user) }"
             :class="[
                 'kiwi-messagelist-nick',
@@ -51,7 +52,7 @@
                     'kiwi-messagelist-nick--mode-'+props.m().userMode(props.message.user) :
                     ''
             ]"
-            @click="props.ml.openUserBox(props.message.nick)"
+            :data-nick="(props.message.nick||'').toLowerCase()"
             @mouseover="props.ml.hover_nick=props.message.nick.toLowerCase();"
             @mouseout="props.ml.hover_nick='';"
         >
@@ -65,7 +66,7 @@
                 {{ props.message.user ? props.m().userModePrefix(props.message.user) : '' }}
             </span>
             {{ props.message.nick }}
-        </div>
+        </a>
         <div
             v-if="props.message.bodyTemplate && props.message.bodyTemplate.$el"
             v-rawElement="props.message.bodyTemplate.$el"

--- a/src/components/MessageListMessageInline.vue
+++ b/src/components/MessageListMessageInline.vue
@@ -43,21 +43,22 @@
             </span>
             <span
                 :style="{ 'color': props.ml.userColour(props.message.user) }"
-                :data-nick="props.message.nick"
                 :class="[
                     'kiwi-messagelist-nick',
                     (props.message.user && props.m().userMode(props.message.user)) ?
                         'kiwi-messagelist-nick--mode-'+props.m().userMode(props.message.user) :
                         ''
                 ]"
-                @click="props.ml.openUserBox(props.message.nick)"
+                :data-nick="(props.message.nick||'').toLowerCase()"
                 @mouseover="props.ml.hover_nick=props.message.nick.toLowerCase();"
                 @mouseout="props.ml.hover_nick='';"
             >
                 <span class="kiwi-messagelist-nick--prefix">
                     {{ props.message.user ? props.m().userModePrefix(props.message.user) : '' }}
                 </span>
-                <span>{{ props.m().displayNick() }}</span>
+                <a :data-nick="(props.message.nick||'').toLowerCase()">
+                    {{ props.m().displayNick() }}
+                </a>
             </span>
             <div
                 v-if="props.message.bodyTemplate && props.message.bodyTemplate.$el"

--- a/src/components/MessageListMessageModern.vue
+++ b/src/components/MessageListMessageModern.vue
@@ -57,7 +57,7 @@
         </div>
         <div class="kiwi-messagelist-modern-right">
             <div class="kiwi-messagelist-top">
-                <div
+                <a
                     v-if="props.message.nick"
                     :style="{ 'color': props.ml.userColour(props.message.user) }"
                     :class="[
@@ -66,7 +66,7 @@
                             'kiwi-messagelist-nick--mode-'+props.m().userMode(props.message.user) :
                             ''
                     ]"
-                    @click="props.ml.openUserBox(props.message.nick)"
+                    :data-nick="(props.message.nick).toLowerCase()"
                     @mouseover="props.ml.hover_nick=props.message.nick.toLowerCase();"
                     @mouseout="props.ml.hover_nick='';"
                 >
@@ -75,11 +75,11 @@
                             props.m().userModePrefix(props.message.user) :
                             ''
                     }}</span>{{ props.message.nick }}
-                </div>
+                </a>
                 <div
                     v-if="props.m().showRealName()"
                     class="kiwi-messagelist-realname"
-                    @click="props.ml.openUserBox(message.nick)"
+                    @click="props.ml.openUserBox(props.message.nick)"
                     @mouseover="props.ml.hover_nick=props.message.nick.toLowerCase();"
                     @mouseout="props.ml.hover_nick='';"
                 >
@@ -161,9 +161,9 @@ const methods = {
         }
 
         // No point showing the realname if it's the same as the nick
-        if (props.message.user.nick.toLowerCase() === props.message.user.realname.toLowerCase()) {
-            return false;
-        }
+        // if (props.message.user.nick.toLowerCase() === props.message.user.realname.toLowerCase()) {
+        //     return false;
+        // }
 
         // If the realname contains a URL it's most likely a clients website
         if (urlRegex.test(props.message.user.realname)) {
@@ -366,6 +366,11 @@ export default {
     font-size: 0.8em;
     font-weight: 400;
     opacity: 0.6;
+}
+
+.kiwi-messagelist-message--modern .kiwi-messagelist-nick {
+    padding: 0;
+    margin-right: 10px;
 }
 
 .kiwi-messagelist-message-traffic .kiwi-messagelist-body {

--- a/src/components/MessageListMessageModern.vue
+++ b/src/components/MessageListMessageModern.vue
@@ -161,9 +161,9 @@ const methods = {
         }
 
         // No point showing the realname if it's the same as the nick
-        // if (props.message.user.nick.toLowerCase() === props.message.user.realname.toLowerCase()) {
-        //     return false;
-        // }
+        if (props.message.user.nick.toLowerCase() === props.message.user.realname.toLowerCase()) {
+            return false;
+        }
 
         // If the realname contains a URL it's most likely a clients website
         if (urlRegex.test(props.message.user.realname)) {


### PR DESCRIPTION
This makes sender nicks linked with click and double click support and improves double click nick insert to have matching case to the users nick

also fixes click on realname in modern layout (missing `prop.`)

closes #1321