### PR TITLE
Use JSON5 for <script name="kiwiConfig">

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import Vue from 'vue';
+import JSON5 from 'json5';
 import i18next from 'i18next';
 import i18nextXHR from 'i18next-xhr-backend';
 import VueI18Next from '@panter/vue-i18next';
@@ -191,7 +192,7 @@ function loadApp() {
         let configContents = document.querySelector('script[name="kiwiconfig"]').innerHTML;
 
         try {
-            configObj = JSON.parse(configContents);
+            configObj = JSON5.parse(configContents);
         } catch (parseErr) {
             log.error('Config file: ' + parseErr.stack);
             showError();


### PR DESCRIPTION
although <script name="kiwiConfig"> is not a great way of storing the config due to the browser giving an error when it tries to execute the script. parsing the contents as JSON5 will make it a little less painful.

always gives: `Uncaught SyntaxError: Unexpected token ':'`