### PR TITLE
Remove avatars default background colour

### DIFF
--- a/static/themes/common/base.css
+++ b/static/themes/common/base.css
@@ -866,7 +866,6 @@
 
 /* ---- Modern Layout Styling ---- */
 .kiwi-avatar > span {
-    background-color: var(--brand-default-fg);
     color: var(--brand-default-bg);
     border-color: var(--brand-primary);
 }


### PR DESCRIPTION
the dark background looks ugly when avatar images have transparent backgrounds

https://imgur.com/a/MPDrqWI

when no image is used the users colour is used for the background