### PR TITLE
Restore bnc username/password from bnc network.

### DIFF
--- a/src/libs/BouncerProvider.js
+++ b/src/libs/BouncerProvider.js
@@ -47,6 +47,16 @@ export default class BouncerProvider {
         this.bnc.path = path || '';
         this.bnc.enabled = true;
 
+        const bncNetwork = this.state.networks.find((network) => network.is_bnc);
+
+        if (bncNetwork?.connection?.password) {
+            let [username, password] = bncNetwork.connection.password.split(':');
+            username = username.split('/')[0];
+
+            this.bnc.username = username;
+            this.bnc.password = password;
+        }
+
         // this.monitorNetworkChanges();
         this.listenToState();
     }

--- a/src/libs/BouncerProvider.js
+++ b/src/libs/BouncerProvider.js
@@ -50,9 +50,7 @@ export default class BouncerProvider {
         const bncNetwork = this.state.networks.find((network) => network.is_bnc);
 
         if (bncNetwork?.connection?.password) {
-            let [username, password] = bncNetwork.connection.password.split(':');
-            username = username.split('/')[0];
-
+            let [username, password] = this.parseBncCredentials(bncNetwork.connection.password);
             this.bnc.username = username;
             this.bnc.password = password;
         }
@@ -98,8 +96,7 @@ export default class BouncerProvider {
 
         // Use this initial network password for other network connections
         if (!this.bnc.username) {
-            let [username, password] = network.connection.password.split(':');
-            username = username.split('/')[0];
+            let [username, password] = this.parseBncCredentials(network.connection.password);
             this.bnc.username = username;
             this.bnc.password = password;
         }
@@ -137,8 +134,10 @@ export default class BouncerProvider {
         // hide the empty (non-network) controller network
         if (!network.ircClient.bnc.hasNetwork()) {
             network.hidden = true;
+            network.is_bnc = true;
         } else {
             network.hidden = false;
+            network.is_bnc = false;
         }
 
         // populate network list from the controller connection
@@ -437,5 +436,12 @@ export default class BouncerProvider {
                 controller.ircClient.bnc.closeBuffer(bncnetid, buffer.name);
             }
         });
+    }
+
+    parseBncCredentials(bncNetworkPassword) {
+        let [username, password] = bncNetworkPassword.split(':');
+        username = username.split('/')[0];
+
+        return [username, password];
     }
 }

--- a/src/libs/BouncerProvider.js
+++ b/src/libs/BouncerProvider.js
@@ -47,8 +47,12 @@ export default class BouncerProvider {
         this.bnc.path = path || '';
         this.bnc.enabled = true;
 
+        // get the bnc controller network
         const bncNetwork = this.state.networks.find((network) => network.is_bnc);
 
+        // the bnc controller network password is saved in the format <username>:<password>.
+        // if there is a bnc controller network with a password, use these credentials
+        // for the bnc connection.
         if (bncNetwork?.connection?.password) {
             let [username, password] = this.parseBncCredentials(bncNetwork.connection.password);
             this.bnc.username = username;

--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -110,6 +110,8 @@ function createNewState() {
                             username: network.username,
                             gecos: network.gecos,
                             password: network.password,
+                            hidden: network.hidden,
+                            is_bnc: network.is_bnc,
                             buffers: [],
                         };
 
@@ -158,6 +160,8 @@ function createNewState() {
                         network.username = importNetwork.username;
                         network.gecos = importNetwork.gecos;
                         network.password = importNetwork.password;
+                        network.hidden = importNetwork.hidden;
+                        network.is_bnc = importNetwork.is_bnc;
 
                         this.networks.push(network);
 

--- a/src/libs/state/NetworkState.js
+++ b/src/libs/state/NetworkState.js
@@ -17,6 +17,7 @@ export default class NetworkState {
         this.last_error = '';
         this.auto_commands = '';
         this.is_znc = false;
+        this.is_bnc = false;
         this.hidden = false;
         this.channel_list = [];
         this.channel_list_state = '';


### PR DESCRIPTION
**Problem**
When the app is using a bouncer, the bouncer sets its credentials when connecting to the bnc network on an `irc.motd` listener. The problem happens when the app loads its networks from the StatePersistence, the bnc credentials will not be set when the app connects to a (non-bnc) network.

**Solution**
This PR makes sure the `BouncerProvider.js` loads the username and password from the BNC network connection on `enable()`.

It also makes sure the network attributes `hidden` and `is_bnc` are persisted.