### PR TITLE
Don't resolve symlinks in webpack

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -21,6 +21,8 @@ module.exports = {
             alias: {
                 vue$: 'vue/dist/vue.common.js',
             },
+            // This prevents yarn link modules from getting linted
+            symlinks: false,
         },
         performance: {
             maxEntrypointSize: 1500000,


### PR DESCRIPTION
This resolves the issue of eslint checking yarn linked modules with kiwiirc rules