### PR TITLE
Prevent buffer.close PART when using bnc

### DIFF
--- a/src/libs/BouncerProvider.js
+++ b/src/libs/BouncerProvider.js
@@ -437,6 +437,8 @@ export default class BouncerProvider {
             }
 
             if (bncnetid) {
+                // The bnc will send the PART so prevent kiwi from doing it
+                event.preventPart = true;
                 controller.ircClient.bnc.closeBuffer(bncnetid, buffer.name);
             }
         });

--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -499,7 +499,7 @@ function createNewState() {
                     return;
                 }
 
-                let eventObj = { buffer };
+                let eventObj = { buffer, preventPart: false };
                 state.$emit('buffer.close', eventObj);
 
                 let bufferIdx = network.buffers.indexOf(buffer);
@@ -515,7 +515,7 @@ function createNewState() {
                     messages.splice(messageIdx, 1);
                 }
 
-                if (buffer.isChannel() && buffer.joined) {
+                if (buffer.isChannel() && buffer.joined && !eventObj.preventPart) {
                     network.ircClient.part(buffer.name);
                 }
 


### PR DESCRIPTION
The bnc will send the PART command, if kiwi sends it too then will cause error not on channel that causes the buffer to reopen to display the error