### PR TITLE
Add ability to set custom username on websockets

### DIFF
--- a/src/components/startups/Welcome.vue
+++ b/src/components/startups/Welcome.vue
@@ -290,6 +290,7 @@ export default {
                 direct: connectOptions.direct,
                 path: connectOptions.direct_path || '',
                 gecos: options.gecos,
+                username: options.username,
             });
 
             // Clear the server buffer in case it already existed and contains messages relating to


### PR DESCRIPTION
You can use "username": "whatever", in config.json file to set your custom ident that you want the websockets clients to use.

Closes #1345