### PR TITLE
Add option for a custom quit message on websockets

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -296,7 +296,7 @@ export default {
 			window.onunload = () => {
 				this.$state.networks.forEach((net) => {
 					if (net.connection.direct && net.state === 'connected') {
-						net.ircClient.raw('QUIT', this.$state.setting('quitMessage') || 'client closed');
+						net.ircClient.raw('QUIT', this.$state.setting('quitMessage') || 'Client Closed Connection');
 					}
 				});
 			};

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -293,13 +293,13 @@ export default {
                 }
                 return undefined;
             };
-			window.onunload = () => {
-				this.$state.networks.forEach((net) => {
-					if (net.connection.direct && net.state === 'connected') {
-						net.ircClient.raw('QUIT', this.$state.setting('quitMessage') || 'Client Closed Connection');
-					}
-				});
-			};
+            window.onunload = () => {
+                this.$state.networks.forEach((net) => {
+                    if (net.connection.direct && net.state === 'connected') {
+                        net.ircClient.raw('QUIT', this.$state.setting('quitMessage') || 'Client Closed Connection');
+                    }
+                });
+            };
         },
         emitBufferPaste(event) {
             // bail if no buffer is active, or the buffer is hidden by another component

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -291,7 +291,6 @@ export default {
                 if (this.$state.setting('warnOnExit')) {
                     return this.$t('window_unload');
                 }
-				
                 return undefined;
             };
 			window.onunload = () => {

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -291,9 +291,16 @@ export default {
                 if (this.$state.setting('warnOnExit')) {
                     return this.$t('window_unload');
                 }
-
+				
                 return undefined;
             };
+			window.onunload = () => {
+				this.$state.networks.forEach((net) => {
+					if (net.connection.direct && net.state === 'connected') {
+						net.ircClient.raw('QUIT', this.$state.setting('quitMessage') || 'Client Closed Connection');
+					}
+				});
+			};
         },
         emitBufferPaste(event) {
             // bail if no buffer is active, or the buffer is hidden by another component

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -296,7 +296,7 @@ export default {
 			window.onunload = () => {
 				this.$state.networks.forEach((net) => {
 					if (net.connection.direct && net.state === 'connected') {
-						net.ircClient.raw('QUIT', this.$state.setting('quitMessage') || 'Client Closed Connection');
+						net.ircClient.raw('QUIT', this.$state.setting('quitMessage') || 'client closed');
 					}
 				});
 			};


### PR DESCRIPTION
This allows you to set ```quitMessage``` option on config.json if you use ```startupOptions.direct``` option, when ever the browser or tab will be closed the websocket will send now a QUIT with a message (like on webircgateway via webirc).
If not any ```quitMessage``` option is set in config.json the default quit will be ```Client Closed Connection```

Config.json Example:

```"quitMessage": "My websocket connection has been closed",```

Credits on @ItsOnlyBinary for the code.