### PR TITLE
Prevents adding messages when there is no network.

### DIFF
--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -549,7 +549,7 @@ function createNewState() {
             addMessage(buffer, message) {
                 // Some messages try to be added after a network has been removed, meaning no buffer
                 // will be available
-                if (!buffer) {
+                if (!buffer || !buffer.getNetwork()) {
                     return;
                 }
 


### PR DESCRIPTION
This small change prevents the app from crashing down the road in `bufferTools.js:30`.
Seems like a good place to add this check.