### PR TITLE
Removes connection messages from messagelist.

### DIFF
--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -697,44 +697,11 @@ div.kiwi-messagelist-item.kiwi-messagelist-item--selected .kiwi-messagelist-mess
     font-size: 80%;
 }
 
+/* Remove the styling for none user messages, as they make the page look bloated */
 .kiwi-messagelist-message-mode,
 .kiwi-messagelist-message-traffic {
     padding-top: 5px;
     padding-bottom: 5px;
-}
-
-/* Start of the not connected message styling */
-.kiwi-messagelist-message-connection {
-    padding: 0;
-    text-align: center;
-    font-weight: bold;
-    border: none;
-    margin: 0;
-    background: none;
-}
-
-.kiwi-messagelist-message-connection .kiwi-messagelist-body {
-    font-size: 1.2em;
-    height: auto;
-    line-height: normal;
-    text-align: center;
-    cursor: default;
-    display: inline-block;
-    padding: 0.5em 1em;
-    margin: 1em auto 1em auto;
-    text-transform: uppercase;
-    letter-spacing: 2px;
-}
-
-.kiwi-messagelist-message-connection .kiwi-messagelist-time,
-.kiwi-messagelist-message-connection .kiwi-messagelist-nick {
-    display: none;
-}
-
-/* Remove the styling for none user messages, as they make the page look bloated */
-.kiwi-messagelist-message-mode,
-.kiwi-messagelist-message-traffic,
-.kiwi-messagelist-message-connection {
     min-height: 0;
     line-height: normal;
     text-align: left;

--- a/src/components/MessageListMessageCompact.vue
+++ b/src/components/MessageListMessageCompact.vue
@@ -234,20 +234,6 @@ export default {
     margin-left: 131px;
 }
 
-.kiwi-messagelist-message--compact.kiwi-messagelist-message-connection .kiwi-messagelist-time {
-    display: none;
-}
-
-.kiwi-messagelist-message--compact.kiwi-messagelist-message-connection .kiwi-messagelist-body {
-    display: inline-block;
-    margin: 0;
-    padding: 10px 0;
-    margin-left: 131px;
-    font-size: 0.8em;
-    opacity: 0.8;
-    font-weight: 600;
-}
-
 //Channel topic
 .kiwi-messagelist-message--compact.kiwi-messagelist-message-topic {
     border-radius: 0;
@@ -359,10 +345,6 @@ export default {
     }
 
     .kiwi-messagelist-message--compact.kiwi-messagelist-message-traffic .kiwi-messagelist-body {
-        margin-left: 181px;
-    }
-
-    .kiwi-messagelist-message--compact.kiwi-messagelist-message-connection .kiwi-messagelist-body {
         margin-left: 181px;
     }
 }

--- a/src/components/MessageListMessageInline.vue
+++ b/src/components/MessageListMessageInline.vue
@@ -199,20 +199,8 @@ export default {
 
 .kiwi-messagelist-message--text .kiwi-messagelist-message-privmsg:hover,
 .kiwi-messagelist-message--text .kiwi-messagelist-message-action:hover,
-.kiwi-messagelist-message--text .kiwi-messagelist-message-notice:hover, {
+.kiwi-messagelist-message--text .kiwi-messagelist-message-notice:hover {
     cursor: pointer;
-}
-
-.kiwi-messagelist-message--text.kiwi-messagelist-message-connection .kiwi-messagelist-body {
-    display: inline-block;
-    margin: 0;
-    font-size: 0.8em;
-    opacity: 0.8;
-    padding: 0;
-}
-
-.kiwi-messagelist-message--text.kiwi-messagelist-message-connection .kiwi-messagelist-time {
-    display: none;
 }
 
 //Channel topic

--- a/src/components/MessageListMessageModern.vue
+++ b/src/components/MessageListMessageModern.vue
@@ -312,28 +312,6 @@ export default {
     display: none;
 }
 
-/* Connection styling */
-.kiwi-messagelist-message--modern.kiwi-messagelist-message-connection {
-    box-sizing: border-box;
-    width: 100%;
-    padding: 10px 0;
-    opacity: 0.8;
-}
-
-.kiwi-messagelist-message--modern.kiwi-messagelist-message-connection .kiwi-messagelist-time,
-.kiwi-messagelist-message--modern.kiwi-messagelist-message-connection .kiwi-messagelist-nick {
-    display: none;
-}
-
-.kiwi-messagelist-message--modern.kiwi-messagelist-message-connection .kiwi-messagelist-body {
-    padding: 0 20px;
-    margin: 0 auto;
-    display: inline-block;
-    font-weight: 600;
-    font-size: 0.8em;
-    opacity: 0.8;
-}
-
 .kiwi-messagelist-message--modern .kiwi-messagelist-body {
     white-space: pre-wrap;
     word-wrap: break-word;
@@ -412,21 +390,6 @@ export default {
 
     .kiwi-messagelist-message--modern {
         margin: 0;
-    }
-
-    .kiwi-messagelist-message--modern.kiwi-messagelist-message-connection {
-        padding: 0;
-        box-sizing: border-box;
-        margin: 0;
-        border: none;
-        width: 100%;
-        border-radius: 0;
-    }
-
-    .kiwi-messagelist-message--modern.kiwi-messagelist-message-connection .kiwi-messagelist-body {
-        line-height: 50px;
-        font-weight: 600;
-        padding: 0 10px;
     }
 
     .kiwi-messagelist-message-action .kiwi-messagelist-modern-left {

--- a/src/libs/IrcClient.js
+++ b/src/libs/IrcClient.js
@@ -162,24 +162,6 @@ function clientMiddleware(state, network) {
         client.on('connected', () => {
             network.state_error = '';
             network.state = 'connected';
-
-            network.buffers.forEach((buffer) => {
-                if (!buffer) {
-                    return;
-                }
-
-                let messageBody = TextFormatting.formatText('network_connected', {
-                    text: TextFormatting.t('connected'),
-                });
-
-                state.addMessage(buffer, {
-                    time: Date.now(),
-                    nick: '',
-                    message: messageBody,
-                    type: 'connection',
-                    type_extra: 'connected',
-                });
-            });
         });
 
         client.on('socket close', (err) => {
@@ -194,18 +176,6 @@ function clientMiddleware(state, network) {
 
                 buffer.joined = false;
                 buffer.clearUsers();
-
-                let messageBody = TextFormatting.formatText('network_disconnected', {
-                    text: TextFormatting.t('disconnected'),
-                });
-
-                state.addMessage(buffer, {
-                    time: Date.now(),
-                    nick: '',
-                    message: messageBody,
-                    type: 'connection',
-                    type_extra: 'disconnected',
-                });
             });
         });
     };

--- a/static/themes/common/base.css
+++ b/static/themes/common/base.css
@@ -845,11 +845,6 @@
     color: var(--brand-default-fg);
 }
 
-/* Connection Styling */
-.kiwi-messagelist-message-connection {
-    background-color: var(--brand-default-bg);
-}
-
 /* ---- Traffic Messages ---- */
 .kiwi-messagelist-message-traffic-join {
     color: var(--brand-primary);

--- a/static/themes/dark/theme.css
+++ b/static/themes/dark/theme.css
@@ -84,8 +84,6 @@ button.u-button.u-button-primary.u-submit.kiwi-welcome-znc-start {
 .kiwi-network-name-option,
 .kiwi-warning-block,
 .kiwi-notconnected-button,
-.kiwi-messagelist-message.kiwi-messagelist-message-connection-disconnected,
-.kiwi-messagelist-message.kiwi-messagelist-message-connection-connected,
 .u-button-warning,
 .kiwi-settings-advanced-notice,
 .kiwi-networksettings .kiwi-title,

--- a/static/themes/radioactive/theme.css
+++ b/static/themes/radioactive/theme.css
@@ -494,10 +494,6 @@
   background: #406550;
   opacity: 1;
 }
-.kiwi-messagelist-message.kiwi-messagelist-message--unread.kiwi-messagelist-message-connection {
-    border-left: none;
-    background: none;
-}
 
 /* When hovering over a users messages */
 .kiwi-messagelist-message--hover{
@@ -507,14 +503,6 @@
 /* The shadow over the main text area that displays when the sidebar is open */
 .kiwi-container--sidebar-drawn .kiwi-messagelist::after {
     background-color: #000;
-}
-
-.kiwi-messagelist-message.kiwi-messagelist-message-connection-connected {
-    background-color: #1b2f24;
-    color: #fff;
-}
-.kiwi-messagelist-message.kiwi-messagelist-message-connection-disconnected {
-    color: #fff;
 }
 
 /* Traffic Messages - User join , User Quit etc*/


### PR DESCRIPTION
Both the web client and the mobile app have the current state of the connection very visible to the user in the top navigation bar. The "connected"/"disconnected" messages are not necessary. On mobile, they are even more annoying because the app connects/disconnects all the time.

This PR removes adding the `connection` messages in the buffer and removes all the styles that were applied to these messages.