### PR TITLE
Welcome: Use saved password

### DIFF
--- a/src/components/startups/Welcome.vue
+++ b/src/components/startups/Welcome.vue
@@ -214,9 +214,17 @@ export default {
         } else {
             this.nick = options.nick;
         }
-
         this.nick = this.processNickRandomNumber(this.nick || '');
-        this.password = options.password || '';
+
+        if (options.password) {
+            this.password = options.password;
+        } else if (previousNet && previousNet.password) {
+            this.password = previousNet.password;
+            this.show_password_box = true;
+        } else {
+            this.password = '';
+        }
+
         this.channel = decodeURIComponent(window.location.hash) || options.channel || '';
         this.showChannel = typeof options.showChannel === 'boolean' ?
             options.showChannel :


### PR DESCRIPTION
Kiwi already stores the network password in localStorage, let's not make the user retype it each time. This is particularly useful for embedded clients with a nontechnical audience, either on servers with a password or servers where the server password is automatically forwarded to NickServ.

Whether it's a good idea to store it at all without the user's explicit request is debatable but a different issue.