### PR TITLE
Welcome: Query param to hide channel field

### DIFF
--- a/src/components/startups/Welcome.vue
+++ b/src/components/startups/Welcome.vue
@@ -218,9 +218,13 @@ export default {
         this.nick = this.processNickRandomNumber(this.nick || '');
         this.password = options.password || '';
         this.channel = decodeURIComponent(window.location.hash) || options.channel || '';
-        this.showChannel = typeof options.showChannel === 'boolean' ?
-            options.showChannel :
-            true;
+        if (this.channel && Misc.queryStringVal('showChannel')) {
+            this.showChannel = Misc.queryStringVal('showChannel') !== 'false';
+        } else {
+            this.showChannel = typeof options.showChannel === 'boolean' ?
+                options.showChannel :
+                true;
+        }
         this.showNick = typeof options.showNick === 'boolean' ?
             options.showNick :
             true;


### PR DESCRIPTION
This adds the ability to hide the channel field from the Welcome page using `?showChannel=false`. The channel field isn't hidden if no channel is provided in the config or the URL.
This is useful for embedded clients that are only meant for use with one channel, reducing user confusion and simplifying the connection form.

Wiki page to update on merge: https://github.com/kiwiirc/kiwiirc/wiki/Linking-to-and-Embedding-Kiwi-IRC#options