### PR TITLE
Welcome: Prefer saved nick

### DIFF
--- a/src/components/startups/Welcome.vue
+++ b/src/components/startups/Welcome.vue
@@ -207,10 +207,10 @@ export default {
             previousNet = this.$state.getNetworkFromAddress(connectOptions.hostname.trim());
         }
 
-        if (Misc.queryStringVal('nick')) {
-            this.nick = Misc.queryStringVal('nick');
-        } else if (previousNet && previousNet.connection.nick) {
+        if (previousNet && previousNet.connection.nick) {
             this.nick = previousNet.connection.nick;
+        } else if (Misc.queryStringVal('nick')) {
+            this.nick = Misc.queryStringVal('nick');
         } else {
             this.nick = options.nick;
         }


### PR DESCRIPTION
This changes the default nickname preference from url > saved > config to saved > url > config.
This is useful for embedded clients and nontechnical users, since it'll remember their preferred nick instead of replacing it with the one from the embed URL each time.