### PR TITLE
Send 'notification.enabled' event

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -180,7 +180,7 @@ export default {
                     this.$state.$off('document.clicked', requestNotificationPermission);
                     this.$state.$off('input.raw', requestNotificationPermission);
 
-                    Notifications.requestPermission();
+                    Notifications.requestPermission(this.$state);
                     Notifications.listenForNewMessages(this.$state);
                 };
 

--- a/src/libs/Notifications.js
+++ b/src/libs/Notifications.js
@@ -4,7 +4,7 @@ import _ from 'lodash';
 
 let isEnabled = false;
 
-export function requestPermission() {
+export function requestPermission(state) {
     // Do we support notifications?
     if (!('Notification' in window)) {
         isEnabled = false;
@@ -13,12 +13,15 @@ export function requestPermission() {
 
     // Permissions already been granted?
     if (Notification.permission === 'granted') {
+        state.$emit('notification.enabled');
         isEnabled = true;
+        return;
     }
 
     if (Notification.permission !== 'denied') {
         Notification.requestPermission((permission) => {
             if (permission === 'granted') {
+                state.$emit('notification.enabled');
                 isEnabled = true;
             } else {
                 isEnabled = false;


### PR DESCRIPTION
This allows plugins to use notifications without having to handle requesting permissions