### PR TITLE
Fix sending multiple lines && add support for alt+enter to add new lines in ControlInput.vue

### DIFF
--- a/src/components/ControlInput.vue
+++ b/src/components/ControlInput.vue
@@ -392,7 +392,15 @@ export default {
                 this.$refs.autocomplete.selectCurrentItem();
             }
 
-            if (event.keyCode === 13) {
+            if (event.keyCode === 13 && (
+                (event.altKey && !event.shiftKey && !event.metaKey && !event.ctrlKey) ||
+                (event.shiftKey && !event.altKey && !event.metaKey && !event.ctrlKey)
+            )) {
+                // Add new line when shift+enter or alt+enter is pressed
+                event.preventDefault();
+                this.$refs.input.insertText('\n');
+            } else if (event.keyCode === 13) {
+                // Send message when enter is pressed
                 event.preventDefault();
                 this.submitForm();
             } else if (event.keyCode === 32) {

--- a/src/libs/InputHandler.js
+++ b/src/libs/InputHandler.js
@@ -150,9 +150,12 @@ function handleMessage(type, event, command, line) {
     // pure whitespace messages which we don't want to interfere with
     if (message.replace(/\s+/g, '') !== '') {
         message = message.trimEnd();
+    } else {
+        // Windows uses \r\n for new lines as we split on \n trim \r from the end
+        message = message.replace(/[\r]+$/, '');
     }
 
-    // Mke sure we have some text to actually send
+    // Make sure we have some text to actually send
     if (!message) {
         return;
     }


### PR DESCRIPTION
fixes sending `test\r\n\r\ntest` on windows

also adds support for alt+enter to add new lines while typing