### PR TITLE
Fix getLoadingState when buffer not joined.

### DIFF
--- a/src/libs/state/BufferState.js
+++ b/src/libs/state/BufferState.js
@@ -529,7 +529,6 @@ export default class BufferState {
             return 'connecting';
         } else if (
             networkState === 'connected' &&
-            this.joined &&
             this.enabled &&
             (
                 historySupport &&


### PR DESCRIPTION
Right now, if a buffer was not joined the loading state would be "done". This doesn't make much sense and not useful anymore as the app code no longer needs this workaround.