### PR TITLE
Use Network name if there is one when creating new bnc-enabled network.

### DIFF
--- a/src/libs/BouncerProvider.js
+++ b/src/libs/BouncerProvider.js
@@ -462,7 +462,7 @@ export default class BouncerProvider {
 
             network.editable_name = true;
 
-            // If network is attached to a bouncer do nothing 
+            // If network is attached to a bouncer do nothing
             // (use the name provided by the bouncer)
             if (network.connection.bncnetid) {
                 return;

--- a/src/libs/BouncerProvider.js
+++ b/src/libs/BouncerProvider.js
@@ -462,22 +462,36 @@ export default class BouncerProvider {
 
             network.editable_name = true;
 
-            // Update the network name to NetworkN if hasn't got once from the bouncer yet
-            if (!network.connection.bncnetid) {
-                let currentNum = 1;
-                let existingNet = true;
-                while (existingNet) {
-                    existingNet = _.find(state.networks, {
-                        name: 'Network' + currentNum,
-                    });
+            // If network is attached to a bouncer do nothing 
+            // (use the name provided by the bouncer)
+            if (network.connection.bncnetid) {
+                return;
+            }
 
-                    if (!existingNet || network === existingNet) {
-                        network.name = 'Network' + currentNum;
-                        existingNet = null;
-                    }
+            let existingNet = true;
 
-                    currentNum++;
+            // append a number to the network name. E.g. "Network, Network2,..."
+            // while there is a network with that name
+            let currentNum = 1;
+            let tryNetworkName;
+            while (existingNet) {
+                if (network.name && currentNum === 1) {
+                    // don't append the number 1 if there is a custom name
+                    tryNetworkName = network.name;
+                } else {
+                    tryNetworkName = (network.name || 'Network') + currentNum;
                 }
+
+                existingNet = _.find(state.networks, {
+                    name: tryNetworkName,
+                });
+
+                if (!existingNet || existingNet === network) {
+                    network.name = tryNetworkName;
+                    break;
+                }
+
+                currentNum++;
             }
         });
 


### PR DESCRIPTION
**Problem:**
When creating a new network with bouncer, the bouncer provider would always replace the network name with `Network1`, `Network2`, etc.

We may want to provide a better network name. E.g., when creating an IRC.com network in the app.

**Solution:**
With this PR, the BouncerProvider will give priority to the network name, if it exists, while making sure the network name is unique (as it used to).
For example, if the new network name is `MyNetwork`, the BouncerProvider will try the names `MyNetwork`, `MyNetwork2`, `MyNetwork3`, etc.
If the network name is not set, the BouncerProvider will behave as preciously and try assigning the names `Network1`, `Network2`, `Network3`, etc.