### PR TITLE
Allows disabling buffer history functionality.

### DIFF
--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -356,7 +356,7 @@ function createNewState() {
                     this.ui.active_network = 0;
                     this.ui.active_buffer = '';
                 } else {
-                    if (this.ui.active_network) {
+                    if (this.settings.useBufferHistory && this.ui.active_network) {
                         // Keep track of last 20 viewed buffers. When closing buffers we can go back
                         // to one of the previous ones
                         this.ui.last_active_buffers.push({
@@ -385,6 +385,12 @@ function createNewState() {
             },
 
             openLastActiveBuffer: function openLastActiveBuffer() {
+                // if not using buffer history, just unset the active buffer
+                if (!this.settings.useBufferHistory) {
+                    this.setActiveBuffer();
+                    return;
+                }
+
                 let targetNetwork;
                 let targetBuffer;
                 let lastActive = this.ui.last_active_buffers;

--- a/src/res/configTemplates.js
+++ b/src/res/configTemplates.js
@@ -105,6 +105,7 @@ export const configTemplates = {
         showAwayStatusIndicators: true,
         sidebarDefault: 'nicklist',
         showRaw: false,
+        useBufferHistory: true,
         hideSettings: null,
         highlights: '',
         teamHighlights: false,


### PR DESCRIPTION
This PR makes possible to disable buffer history and the activate previous buffer functionality.

The reason is that some clients may not want this behaviour. For instance, in the mobile app where navigating automatically to a buffer would feel confusing.