### PR TITLE
Added show_presence_changes setting.

### DIFF
--- a/src/libs/bufferTools.js
+++ b/src/libs/bufferTools.js
@@ -60,24 +60,25 @@ export function orderedMessages(buffer, opts = {}) {
         return messages;
     }
 
+    let messageTypesToShowSetting = {
+        // message.type: 'settings_name'
+        traffic: 'show_joinparts',
+        topic: 'show_topics',
+        nick: 'show_nick_changes',
+        mode: 'show_mode_changes',
+        presence: 'show_presence_changes',
+    };
+
+    let hiddenMessageTypes = Object.keys(messageTypesToShowSetting)
+        .filter((type) => !buffer.setting(messageTypesToShowSetting[type]));
+
     let list = [];
-    let showJoinParts = buffer.setting('show_joinparts');
-    let showTopics = buffer.setting('show_topics');
-    let showNickChanges = buffer.setting('show_nick_changes');
-    let showModeChanges = buffer.setting('show_mode_changes');
     for (let i = messages.length - 1; i >= 0; i--) {
-        if (!showJoinParts && messages[i].type === 'traffic') {
+        // don't include hidden message types
+        if (hiddenMessageTypes.includes(messages[i].type)) {
             continue;
         }
-        if (!showTopics && messages[i].type === 'topic') {
-            continue;
-        }
-        if (!showNickChanges && messages[i].type === 'nick') {
-            continue;
-        }
-        if (!showModeChanges && messages[i].type === 'mode') {
-            continue;
-        }
+
         // Ignored users have the ignore flag set
         if (messages[i].ignore) {
             continue;

--- a/src/res/configTemplates.js
+++ b/src/res/configTemplates.js
@@ -58,6 +58,7 @@ export const configTemplates = {
             show_topics: true,
             show_nick_changes: true,
             show_mode_changes: true,
+            show_presence_changes: true,
             traffic_as_activity: false,
             coloured_nicklist: true,
             colour_nicknames_in_messages: true,


### PR DESCRIPTION
This PR adds the setting `show_presence_changes`. If false, the presence messages (away/back) are filtered out from the message list in `bufferTools.orderedMessages()`.

By default, the setting will be set to `true`, and the current behaviour will not be changed.

On the mobile app this setting will be `false` because the message was being shown all the time when the app boots or resumes, and because the status indicator next to avatar is enough to show this information to the user.