### PR TITLE
Fixes buffer importState when there is no latest_messages;

### DIFF
--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -182,7 +182,8 @@ function createNewState() {
                             buffer.enabled = !!impBuffer.enabled;
                             buffer.settings = impBuffer.settings;
 
-                            impBuffer.latest_messages.forEach((msg) => {
+                            let latestMessages = impBuffer.latest_messages || [];
+                            latestMessages.forEach((msg) => {
                                 buffer.latest_messages.push(new Message(msg));
                             });
 


### PR DESCRIPTION
The code would break when loading the serialised buffer if `latest_messages` didn't exist.