### PR TITLE
Fix input wrapping

### DIFF
--- a/src/components/ControlInput.vue
+++ b/src/components/ControlInput.vue
@@ -781,7 +781,6 @@ export default {
     height: 100%;
     box-sizing: border-box;
     overflow: visible;
-    padding: 7px 0 12px 0;
 }
 
 .kiwi-controlinput-tool {

--- a/src/components/utils/IrcInput.vue
+++ b/src/components/utils/IrcInput.vue
@@ -450,6 +450,7 @@ export default Vue.component('irc-input', {
 .kiwi-ircinput-editor {
     overflow-x: hidden;
     outline: none;
+    padding: 7px 0 12px 0;
 
     /* When the contenteditable div is empty firefox makes its height 0px */
     height: 100%;


### PR DESCRIPTION
This makes the input box easier to select by giving it a wider zone without changing appearance.

closes #1405