### PR TITLE
Allow channel name from location query params

### DIFF
--- a/src/components/startups/Welcome.vue
+++ b/src/components/startups/Welcome.vue
@@ -225,7 +225,8 @@ export default {
             this.password = '';
         }
 
-        this.channel = decodeURIComponent(window.location.hash) || options.channel || '';
+        const params = new URLSearchParams(window.location.search);
+        this.channel = decodeURIComponent(window.location.hash) || params.get('channel') || options.channel || '';
         this.showChannel = typeof options.showChannel === 'boolean' ?
             options.showChannel :
             true;


### PR DESCRIPTION
We cannot use the location anchor to prefill the channel with a direct
private channel to some user nick. As "#foobar" will previll the public
channel "#foobar" and not "foobar"

This patch allow the query parameter "?channel=foobar" to prefill the
channel input with a direct private channel and not a public one.

This will not break existing links cause we do not change the previous
url anchor way.