### PR TITLE
Fix autocomplete not completing and emptying input in particular contexts.

### DIFF
--- a/src/components/AutoComplete.vue
+++ b/src/components/AutoComplete.vue
@@ -143,6 +143,8 @@ export default {
 
             let cancelKeyCodes = [
                 13, // return
+                32, // space
+                186, // semi-colon
                 188, // comma
                 190, // period
             ];

--- a/src/components/ControlInput.vue
+++ b/src/components/ControlInput.vue
@@ -372,7 +372,7 @@ export default {
         },
         onAutocompleteSelected(selectedValue, selectedItem) {
             let word = selectedValue;
-            this.$refs.input.setCurrentWord(word);
+            if (word.length > 0) this.$refs.input.setCurrentWord(word);
             this.autocomplete_open = false;
         },
         inputKeyDown(event) {

--- a/src/components/ControlInput.vue
+++ b/src/components/ControlInput.vue
@@ -372,7 +372,9 @@ export default {
         },
         onAutocompleteSelected(selectedValue, selectedItem) {
             let word = selectedValue;
-            if (word.length > 0) this.$refs.input.setCurrentWord(word);
+            if (word.length > 0) {
+                this.$refs.input.setCurrentWord(word);
+            }
             this.autocomplete_open = false;
         },
         inputKeyDown(event) {


### PR DESCRIPTION
This fixes 2 bugs:

- When autocomplete has already been triggered, it wont be triggered again. This breaks usages like /kick nick+tab. If the user has typed a space or a semi-colon, the auto-complete should be reset.
- When typing something+tab+continue typing and the tab doesn't match any auto-complete proposal, the input is reset and it should not.

closes #1388, closes #1471