### PR TITLE
Increase preview provider max height to better embed vidoes on lower screen heights

### DIFF
--- a/src/components/PreviewProvider.vue
+++ b/src/components/PreviewProvider.vue
@@ -58,7 +58,7 @@ export default {
                         this.$el.style.maxHeight = (this.settings.maxHeight || 400) + 'px';
                     } else {
                         // This is main media view set a relative max height
-                        this.$emit('setMaxHeight', '40%');
+                        this.$emit('setMaxHeight', '54%');
                     }
                 });
             };
@@ -82,7 +82,7 @@ export default {
 
     .embedly-card {
         display: block;
-        margin: 10px 0;
+        margin: 4px 0;
     }
 
     .embedly-card-hug {


### PR DESCRIPTION
This will allow embedly to show videos in the main media viewer without scrollbars on browsers with a body height of >= 752px  (900px height screen, chrome + address bar + bookmark bar)


Not sure if this should be 65% which would allow no scrollbars on 768 screen, 65% feels like its giving too much space.