### PR TITLE
FIX: Navcontainer active items overlap by one pixel when active

### DIFF
--- a/src/components/ContainerHeader.vue
+++ b/src/components/ContainerHeader.vue
@@ -342,7 +342,7 @@ export default {
 .kiwi-header-option a {
     float: left;
     padding: 0 15px;
-    line-height: 45px;
+    line-height: 43px;
     display: block;
     font-weight: 600;
     opacity: 0.8;
@@ -357,7 +357,7 @@ export default {
 .kiwi-header-option i {
     font-size: 1.2em;
     float: left;
-    line-height: 45px;
+    line-height: 43px;
 }
 
 .kiwi-header-options i + span {


### PR DESCRIPTION
A super quick fix that reduces the line height of some child items to ensure that the navContainer items do not exceed the parent.

Without fix:
![image](https://user-images.githubusercontent.com/11334905/106389996-233caa80-63de-11eb-85bc-22a6b9bce19d.png)


With Fix:
![image](https://user-images.githubusercontent.com/11334905/106389977-11f39e00-63de-11eb-90ea-6ba9aa0b0b05.png)
