### PR TITLE
Support for longer nicknames in the Users Nicklist sidebar

### DIFF
--- a/src/components/NicklistUser.vue
+++ b/src/components/NicklistUser.vue
@@ -128,7 +128,11 @@ export default {
 .kiwi-nicklist-user-nick {
     font-weight: bold;
     cursor: pointer;
-    flex: 1;
+    display: block;
+    width: 100%;
+    padding-right: 20px;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .kiwi-nicklist-messageuser {


### PR DESCRIPTION
- Fix for #1231 
- Style change to the nicklist name, ensuring long names have ellipses
- Add padding to the right side of nickname so the 'message' icon is never obscured 

Without Fix:
![image](https://user-images.githubusercontent.com/11334905/106466384-2ba2ed00-6493-11eb-9387-f87c13ada24c.png)


With Fix:
![image](https://user-images.githubusercontent.com/11334905/106466202-f3031380-6492-11eb-9480-626df5414329.png)
