### PR TITLE
Filter outgoing lines without content when converting from contenteditable html

### DIFF
--- a/src/components/utils/IrcInput.vue
+++ b/src/components/utils/IrcInput.vue
@@ -26,6 +26,7 @@
 import _ from 'lodash';
 import * as htmlparser from 'htmlparser2';
 import * as Colours from '@/helpers/Colours';
+import * as Misc from '@/helpers/Misc';
 
 let Vue = require('vue');
 
@@ -204,7 +205,8 @@ export default Vue.component('irc-input', {
                     // IE11 doesnt support document.execCommand('styleWithCSS')
                     // so we have individual nodes instead, which are handled below
                     } else if (attribs.color) {
-                        // IE likes to remove spaces from rgb(1, 2, 3) it also likes converting rgb to hex
+                        // IE likes to remove spaces from rgb(1, 2, 3)
+                        // it also likes converting rgb to hex
                         let mappedCode = this.code_map[attribs.color] ||
                             this.code_map[attribs.color.replace(/,/g, ', ')] ||
                             this.code_map[Colours.hex2rgb(attribs.color)];
@@ -246,11 +248,12 @@ export default Vue.component('irc-input', {
                 decodeEntities: true,
             });
 
-            /* eslint max-len: off */
             parser.write(source);
             parser.end();
 
-            return textValue;
+            // Firefox likes to add <br/> at the end (some times inside the span)
+            // fix by filtering out any lines that contain no content
+            return textValue.split(/\r?\n/).filter((line) => !!Misc.stripStyles(line)).join('\n');
         },
         reset(rawHtml) {
             this.$refs.editor.innerHTML = rawHtml || '';


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=503838

Dumping values from [buildIrcText()](https://github.com/kiwiirc/kiwiirc/blob/d5f7e96ef2ae70c5a72a0b6c811793ff9d57a1b2/src/components/utils/IrcInput.vue#L252) in Firefox 85.0.2 (win64)

source: `<span style="color: rgb(255, 89, 89);">test test <br></span>`
textValue: `%0304test%20test%20%0A%0304`  (this value has been through encodeURI() to show all chars)

closes #1420