### PR TITLE
Partially Revert "Add services aliases and notice prefix"

### DIFF
--- a/src/res/configTemplates.js
+++ b/src/res/configTemplates.js
@@ -123,11 +123,6 @@ export const configTemplates = {
 /cycle $channel? /lines /part $channel | /join $channel
 /active /back $1+
 /umode /mode $nick $1+
-/cs /msg chanserv $1+
-/ns /msg nickserv $1+
-/bs /msg botserv $1+
-/hs /msg hostserv $1+
-/os /msg operserv $1+
 
 # Op related aliases
 /op /quote mode $channel +o $1+


### PR DESCRIPTION
These command aliases should be implemented in the ircd, config.json or plugin. Setting them by default prevents ircd implementation.

This partially reverts commit a8ae262d44fe4018b735d016e8d1b6ee82406c0b.