### PR TITLE
Add topic in header with irc markup

### DIFF
--- a/src/components/ContainerHeader.vue
+++ b/src/components/ContainerHeader.vue
@@ -8,6 +8,9 @@
             <div class="kiwi-header-name-container">
                 <div class="kiwi-header-name">{{ buffer.name }}</div>
             </div>
+            <div class="kiwi-header-topic-container">
+                <div class="kiwi-header-topic" v-html="formattedTopic"></div>
+            </div>
             <div
                 v-if="isJoined && isConnected"
                 :key="buffer.id"
@@ -266,6 +269,15 @@ export default {
                 network.ircClient.join(channelName);
             }
         },
+        b() {
+            return this.buffer || {};
+        },
+
+        formattedHeader() {
+            let blocks = parseMessage(this.buffer.topic || '', { extras: false });
+            let content = toHtml(blocks);
+            return content;
+        },
     },
 };
 </script>
@@ -303,11 +315,27 @@ export default {
     cursor: default;
     margin: 0;
     margin-right: 0.5em;
+    max-width: 40%;
     opacity: 1;
     font-size: 20px;
     line-height: 43px;
     flex-grow: 1;
     text-align: left;
+    overflow-x: hidden;
+    white-space: nowrap;
+}
+
+.kiwi-header-topic-container {
+    font-weight: bold;
+    cursor: default;
+    margin: 0;
+    margin-right: 0.5em;
+    max-width: 60%;
+    opacity: 1;
+    font-size: 20px;
+    line-height: 43px;
+    flex-grow: 1;
+    text-align: right;
     overflow-x: hidden;
     white-space: nowrap;
 }
@@ -318,9 +346,16 @@ export default {
     padding: 0 10px;
 }
 
+.kiwi-header-topic {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    padding: 0 5px;
+}
+
 .kiwi-header-name:hover {
     position: absolute;
     padding-right: 10px;
+    background-color: #666;
     z-index: 1;
 }
 


### PR DESCRIPTION
This adds the topic in the header including the colors as it is shown on IRC itself.
Topic is same as the channelname, ellipsis when too long.
when hovering channelname, channelname gives a background for better reading as the :hover gives z-index 1