### PR TITLE
Fix a style issue on "Join Channel" button

### DIFF
--- a/static/themes/common/base.css
+++ b/static/themes/common/base.css
@@ -169,7 +169,7 @@
 
 .kiwi-header .kiwi-header-notjoined .u-link {
     background-color: var(--brand-primary);
-    color: var(--brand-default-bg);
+    color: var(--brand-default-fg);
 }
 
 .kiwi-header .kiwi-header-notjoined .u-link:hover {


### PR DESCRIPTION
The button "Join Channel" was not clearly displayed, tested on all themes and this change seems to fix that issue.

Before:
![before](https://i.imgur.com/2fhDA0P.png)

After:
![after](https://i.imgur.com/7hzihuA.png)