### PR TITLE
Implement support for helpop command (irc-fw 'help' event)

### DIFF
--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -715,7 +715,8 @@ div.kiwi-messagelist-item.kiwi-messagelist-item--selected .kiwi-messagelist-mess
     margin: 0;
 }
 
-.kiwi-wrap--monospace .kiwi-messagelist-message {
+.kiwi-wrap--monospace .kiwi-messagelist-message,
+.kiwi-messagelist-message.kiwi-messagelist-message-help {
     font-family: Consolas, monaco, monospace;
     font-size: 80%;
 }

--- a/src/libs/IrcClient.js
+++ b/src/libs/IrcClient.js
@@ -1216,6 +1216,18 @@ function clientMiddleware(state, network) {
             }
         }
 
+        if (command === 'help') {
+            let buffer = state.getOrAddBufferByName(networkid, '*help');
+            state.addMessage(buffer, {
+                time: eventTime,
+                server_time: serverTime,
+                nick: '',
+                message: event.help,
+                type: 'help',
+                tags: event.tags || {},
+            });
+        }
+
         if (command === 'ctcp response' || command === 'ctcp request') {
             let buffer = network.bufferByName(event.target) || network.serverBuffer();
             let textFormatId = command === 'ctcp response' ?


### PR DESCRIPTION
Note: I've forced monospace for help messages, as inspircd relies on this for formatting