### PR TITLE
Statebrowser groups multiple fixes/improvements

### DIFF
--- a/src/components/StateBrowserNetwork.vue
+++ b/src/components/StateBrowserNetwork.vue
@@ -116,6 +116,7 @@
                     class="kiwi-statebrowser-channels-header"
                 >
                     <div
+                        v-if="(type === 'queries' && itemBuffers.length) || type !== 'queries'"
                         class="kiwi-statebrowser-buffertype"
                         @click="toggleSection(type)"
                     >

--- a/src/components/StateBrowserNetwork.vue
+++ b/src/components/StateBrowserNetwork.vue
@@ -112,7 +112,7 @@
                 class="kiwi-statebrowser-buffers"
             >
                 <div
-                    v-if="!channel_filter_display && type !== 'other'"
+                    v-if="!channel_filter_display && showBufferGroups && type !== 'other'"
                     class="kiwi-statebrowser-channels-header"
                 >
                     <div
@@ -304,6 +304,9 @@ export default {
         },
         queryActivity() {
             return this.activityFromBuffers(this.filteredBuffersByType.queries);
+        },
+        showBufferGroups() {
+            return this.$state.setting('buffers.show_buffer_groups');
         },
     },
     methods: {

--- a/src/components/StateBrowserNetwork.vue
+++ b/src/components/StateBrowserNetwork.vue
@@ -111,7 +111,10 @@
                 :data-name="type"
                 class="kiwi-statebrowser-buffers"
             >
-                <div v-if="!channel_filter_display" class="kiwi-statebrowser-channels-header">
+                <div
+                    v-if="!channel_filter_display && type !== 'other'"
+                    class="kiwi-statebrowser-channels-header"
+                >
                     <div
                         class="kiwi-statebrowser-buffertype"
                         @click="toggleSection(type)"
@@ -181,7 +184,8 @@
                     </div>
                 </div>
                 <div v-if="(show_channels && type === 'channels') ||
-                    (show_queries && type === 'queries')"
+                    (show_queries && type === 'queries') ||
+                    type === 'other'"
                 >
                     <buffer
                         v-for="buffer in itemBuffers"
@@ -277,6 +281,7 @@ export default {
         },
         filteredBuffersByType() {
             let ret = {
+                other: [],
                 channels: [],
                 queries: [],
             };
@@ -285,7 +290,9 @@ export default {
                 if (bufferObj.isChannel()) {
                     ret.channels.push(bufferObj);
                 } else if (bufferObj.isQuery()) {
-                    ret.queries.push((bufferObj));
+                    ret.queries.push(bufferObj);
+                } else {
+                    ret.other.push(bufferObj);
                 }
             });
 

--- a/src/components/StateBrowserNetwork.vue
+++ b/src/components/StateBrowserNetwork.vue
@@ -293,6 +293,7 @@ export default {
                 } else if (bufferObj.isQuery()) {
                     ret.queries.push(bufferObj);
                 } else {
+                    // This is buffers like *raw, *bnc, *status etc
                     ret.other.push(bufferObj);
                 }
             });

--- a/src/res/configTemplates.js
+++ b/src/res/configTemplates.js
@@ -80,6 +80,7 @@ export const configTemplates = {
             show_link_previews: true,
             inline_link_auto_previews: true,
             inline_link_auto_preview_whitelist: '.*',
+            show_buffer_groups: true,
         },
         // Startup screen default
         startupOptions: {


### PR DESCRIPTION
- Fix showing buffers other than channel/query eg `*raw` or `*bnc`
- Don't show messages group when there are no queries
- Add setting to enable/disable buffer groups 