### PR TITLE
Change IRC-colour-green to standard

### DIFF
--- a/static/themes/default/theme.css
+++ b/static/themes/default/theme.css
@@ -56,7 +56,7 @@
 .irc-fg-colour-white { color: #fff; }
 .irc-fg-colour-black { color: #000; }
 .irc-fg-colour-blue { color: #00f; }
-.irc-fg-colour-green { color: #0f0; }
+.irc-fg-colour-green { color: #009300; }
 .irc-fg-colour-light-red { color: #ff5959; }
 .irc-fg-colour-brown { color: #743a00; }
 .irc-fg-colour-purple { color: #a500ff; }
@@ -73,7 +73,7 @@
 .irc-bg-colour-white { background-color: #fff; }
 .irc-bg-colour-black { background-color: #000; }
 .irc-bg-colour-blue { background-color: #00f; }
-.irc-bg-colour-green { background-color: #0f0; }
+.irc-bg-colour-green { background-color: #009300; }
 .irc-bg-colour-light-red { background-color: #ff5959; }
 .irc-bg-colour-brown { background-color: #743a00; }
 .irc-bg-colour-purple { background-color: #a500ff; }


### PR DESCRIPTION
Changes the irc-fg and irc-bg colour to the standard color used across IRC applications ( #009300 ) in the default kiwi theme.