### PR TITLE
Add language label to language dropdown

### DIFF
--- a/src/components/AppSettings.vue
+++ b/src/components/AppSettings.vue
@@ -14,7 +14,7 @@
                         <h3>{{ $t('settings_general') }}</h3>
                         <div class="kiwi-appsettings-section kiwi-appsettings-general">
                             <label class="kiwi-appsettings-setting-language">
-                                <span>{{ $t('settings_language') }} </span>
+                                <span>{{ $t('settings_language') }}</span>
                                 <div><i class="fa fa-globe" /></div>
                                 <select v-model="settingLanguage">
                                     <option value="">
@@ -421,6 +421,11 @@ export default {
     flex-grow: 1;
     text-align: right;
     margin-right: 1em;
+}
+
+.kiwi-appsettings-setting-language .fa-globe {
+    vertical-align: middle;
+    font-size: 1.8em;
 }
 
 .kiwi-appsettings-setting-theme span {

--- a/src/components/AppSettings.vue
+++ b/src/components/AppSettings.vue
@@ -14,6 +14,7 @@
                         <h3>{{ $t('settings_general') }}</h3>
                         <div class="kiwi-appsettings-section kiwi-appsettings-general">
                             <label class="kiwi-appsettings-setting-language">
+                                <span>{{ $t('settings_language') }} </span>
                                 <div><i class="fa fa-globe" /></div>
                                 <select v-model="settingLanguage">
                                     <option value="">


### PR DESCRIPTION
- Adds a translatable string into the settings to make the dropdown more obvious to users.
- The string is translating, so it looks like it was removed at some point ( I can only assume by mistake?) 

![image](https://user-images.githubusercontent.com/11334905/117581448-b2034680-b0f4-11eb-9ec5-bfb535759ece.png)
