### PR TITLE
Restyle the 'close' button on the AppSettings section

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -423,7 +423,7 @@ body {
     right: auto;
     margin-top: -4px;
     width: 100%;
-    height: 7px;
+    height: 4px;
     z-index: 0;
     transition: width 0.3s;
 }

--- a/src/components/AppSettings.vue
+++ b/src/components/AppSettings.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="kiwi-appsettings">
 
-        <div class="kiwi-appsettings-title" @click="closeSettings">
+        <div class="kiwi-appsettings-close" @click="closeSettings">
             <span>{{ $t('close') }}</span>
             <i class="fa fa-times" aria-hidden="true" />
         </div>
@@ -397,8 +397,8 @@ export default {
     box-sizing: border-box;
     height: 100%;
     overflow-y: auto;
-    padding: 8px 0 0 0;
-    margin-top: -7px;
+    padding: 0;
+    position: relative;
 
     .u-form {
         width: 100%;
@@ -450,10 +450,6 @@ export default {
 
 .kiwi-appsettings-tab-container {
     width: 100%;
-}
-
-.kiwi-appsettings-close {
-    float: right;
 }
 
 .kiwi-appsettings .u-form label {
@@ -509,28 +505,27 @@ export default {
     max-width: 750px;
 }
 
-.kiwi-appsettings-title {
-    display: block;
+.kiwi-appsettings-close {
     cursor: pointer;
+    position: absolute;
+    top: 0;
+    right: 0;
     padding: 0 10px;
-    margin: -1px 0 0 0;
     font-weight: 600;
-    width: 100%;
-    position: relative;
     box-sizing: border-box;
     text-transform: uppercase;
-    line-height: 47px;
+    line-height: 55px;
     text-align: right;
     transition: background 0.3s;
 }
 
-.kiwi-appsettings-title h2 {
+.kiwi-appsettings-close h2 {
     padding: 10px 0 11px 20px;
     width: auto;
     float: left;
 }
 
-.kiwi-appsettings-title a {
+.kiwi-appsettings-close a {
     float: right;
     position: static;
     background: none;
@@ -539,11 +534,11 @@ export default {
     font-size: 1.4em;
 }
 
-.kiwi-appsettings-title i {
+.kiwi-appsettings-close i {
     margin-left: 10px;
     font-size: 1.5em;
     float: right;
-    line-height: 47px;
+    line-height: 53px;
 }
 
 .kiwi-appsettings-messagelistDisplay select {

--- a/static/themes/coffee/theme.css
+++ b/static/themes/coffee/theme.css
@@ -47,7 +47,7 @@
     --comp-border: #b2b2b2;
 }
 
-.kiwi-appsettings-title,
+.kiwi-appsettings-close,
 .kiwi-appsettings-block h3,
 .kiwi-networksettings .kiwi-title,
 .u-form input[type='checkbox']:after, .u-form input[type='radio']:after {

--- a/static/themes/common/base.css
+++ b/static/themes/common/base.css
@@ -693,12 +693,12 @@
     color: var(--brand-default-bg);
 }
 
-.kiwi-appsettings-title {
+.kiwi-appsettings-close {
     background-color: var(--brand-primary);
     color: var(--brand-default-bg);
 }
 
-.kiwi-appsettings-title:hover {
+.kiwi-appsettings-close:hover {
     background: var(--brand-error);
 }
 

--- a/static/themes/grayfox/theme.css
+++ b/static/themes/grayfox/theme.css
@@ -47,7 +47,7 @@
     --comp-border: #b2b2b2;
 }
 
-.kiwi-appsettings-title,
+.kiwi-appsettings-close,
 .kiwi-appsettings-block h3,
 .kiwi-networksettings .kiwi-title,
 .u-form input[type='checkbox']:after, .u-form input[type='radio']:after {

--- a/static/themes/nightswatch/theme.css
+++ b/static/themes/nightswatch/theme.css
@@ -73,14 +73,14 @@
     background-color: #000;
 }
 
-.kiwi-appsettings-title,
+.kiwi-appsettings-close,
 .kiwi-appsettings-block h3,
 .kiwi-networksettings .kiwi-title {
     background-color: var(--brand-primary);
 }
 
 .kiwi-appsettings-block h3,
-.kiwi-appsettings-title {
+.kiwi-appsettings-close {
     color: var(--brand-default-fg);
 }
 

--- a/static/themes/radioactive/theme.css
+++ b/static/themes/radioactive/theme.css
@@ -174,11 +174,11 @@
 }
 
 /* Title bar, at the top of the Application settings component */
-.kiwi-appsettings-title {
+.kiwi-appsettings-close {
     color: #fff;
     background: #031e11;
 }
-.kiwi-appsettings-title:hover{
+.kiwi-appsettings-close:hover{
     background: #5cd894;
 }
 

--- a/static/themes/radioactive/theme.css
+++ b/static/themes/radioactive/theme.css
@@ -175,9 +175,15 @@
 
 /* Title bar, at the top of the Application settings component */
 .kiwi-appsettings-close {
+    line-height: 38px;
     color: #fff;
     background: #031e11;
 }
+
+.kiwi-appsettings-close i {
+    line-height: 38px;
+}
+
 .kiwi-appsettings-close:hover{
     background: #5cd894;
 }


### PR DESCRIPTION
This PR restyles the 'close' heading on the appsettings to a smaller, more user friendly, right aligned button. 
This has the benefit of swapping between the views far less ugly to the user, since the green 'kiwi bar' at the top of both views is consistently sized.

**Before:**
![image](https://user-images.githubusercontent.com/11334905/117582029-fb08ca00-b0f7-11eb-897e-55305d37ade6.png)

**After:**
![image](https://user-images.githubusercontent.com/11334905/117582052-0f4cc700-b0f8-11eb-8919-14a812a8726f.png)

There is a discussion to be had about changing the colour to something other than green, as the user would most likely be expecting an orange/red close button, but that's for another PR :) 


- Rename appsettings title classname to something more fitting
- Update classname in themes
-  restyle the element from a full width element to a smaller, more compact right aligned close button
- Makes opening the appsettings section far less jaring to the user