### PR TITLE
Set IrcInput focus on reset to keep keyboard active on mobiles

### DIFF
--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -1,6 +1,7 @@
 <template>
     <div
         :key="'messagelist-' + buffer.name"
+        v-resizeobserver="onListResize"
         class="kiwi-messagelist"
         :class="{'kiwi-messagelist--smoothscroll': smooth_scroll}"
         @click.self="onListClick"
@@ -452,8 +453,8 @@ export default {
             }
         },
         onListResize(e) {
-            // The messagelist has resized or had new content added so check if we should auto
-            // scroll down to the bottom
+            // The messagelist or interface has resized or had new content added
+            // check if we should auto scroll down to the bottom
             this.maybeScrollToBottom();
         },
         scrollToBottom() {

--- a/src/components/utils/IrcInput.vue
+++ b/src/components/utils/IrcInput.vue
@@ -268,8 +268,10 @@ export default Vue.component('irc-input', {
                 br.parentNode.removeChild(br);
             }
 
+            // Always refocus the input on reset to keep the keyboard active on mobile
+            this.focus();
+
             if (this.default_colour) {
-                this.focus();
                 this.setColour(this.default_colour.code, this.default_colour.colour);
             }
 


### PR DESCRIPTION
This is mostly when using the send button in ControlInput rather than the send button on the keyboard