### PR TITLE
Ensure all button elements have type attribute

### DIFF
--- a/src/components/ChannelInvitelist.vue
+++ b/src/components/ChannelInvitelist.vue
@@ -31,14 +31,14 @@
                                 :key="user.nick" :value="user.account"
                             >{{ user.account }}</option>
                         </select>
-                        <button @click="addAccountInvite($refs.addInviteList.value)">
+                        <button type="button" @click="addAccountInvite($refs.addInviteList.value)">
                             {{ $t('invite_add_invite') }}
                         </button>
                     </template>
                 </div>
                 <div v-if="!supportsAccounts && areWeAnOp" class="kiwi-invitelist-addmask">
                     <input ref="addInviteText" type="text" class="u-input">
-                    <button @click="addInvite($refs.addInviteText.value)">
+                    <button type="button" @click="addInvite($refs.addInviteText.value)">
                         {{ $t('invite_add_invite') }}
                     </button>
                 </div>

--- a/src/components/NetworkSettings.vue
+++ b/src/components/NetworkSettings.vue
@@ -146,6 +146,7 @@
 
                 <button
                     v-if="network.state === 'disconnected'"
+                    type="button"
                     class="u-button kiwi-connect-to-newnetwork"
                     @click="connect()"
                 >
@@ -153,6 +154,7 @@
                 </button>
                 <button
                     v-else-if="network.state === 'connecting'"
+                    type="button"
                     class="u-button kiwi-connect-to-newnetwork"
                     disabled
                 >

--- a/src/components/UserBox.vue
+++ b/src/components/UserBox.vue
@@ -119,6 +119,7 @@
                 </label>
                 <label v-if="isUserOnBuffer">
                     <button
+                        type="button"
                         class="u-button u-button-secondary
                                kiwi-userbox-opaction-kick kiwi-userbox-opaction"
                         @click="kickUser"
@@ -129,6 +130,7 @@
                 </label>
                 <label>
                     <button
+                        type="button"
                         class="u-button u-button-secondary
                                kiwi-userbox-opaction-ban kiwi-userbox-opaction"
                         @click="banUser"
@@ -139,6 +141,7 @@
                 </label>
                 <label v-if="isUserOnBuffer">
                     <button
+                        type="button"
                         class="u-button u-button-secondary
                                kiwi-userbox-opaction-kickban kiwi-userbox-opaction"
                         @click="kickbanUser"

--- a/src/components/startups/Personal.vue
+++ b/src/components/startups/Personal.vue
@@ -13,17 +13,24 @@
                 <p v-html="$t('personal_connect_to', { network: `<b>${server.server}</b>` })" />
                 <button
                     v-if="hasOtherTab"
+                    type="button"
                     class="u-button u-button-primary"
                     @click="addNetworkToExistingTab"
                 >
                     {{ $t('personal_add_existing_tab') }}
                 </button>
-                <button v-else class="u-button u-button-primary" @click="addNetwork()">
+                <button
+                    v-else
+                    type="button"
+                    class="u-button u-button-primary"
+                    @click="addNetwork()"
+                >
                     Add network to Kiwi
                 </button>
 
                 <br>
                 <button
+                    type="button"
                     class="u-button u-button-primary"
                     @click="addNetwork(true)"
                 >
@@ -35,7 +42,7 @@
             <p>{{ $t('personal_addjoin') }}</p>
             <p>{{ $t('personal_return') }}</p>
 
-            <button class="u-button u-button-primary" @click="addEmptyNetwork">
+            <button type="button" class="u-button u-button-primary" @click="addEmptyNetwork">
                 {{ $t('personal_add') }}
             </button> <br>
 

--- a/src/components/startups/Welcome.vue
+++ b/src/components/startups/Welcome.vue
@@ -70,6 +70,7 @@
                 />
                 <button
                     v-else
+                    type="button"
                     class="u-button u-button-primary u-submit kiwi-welcome-simple-start"
                     disabled
                 >

--- a/src/thirdparty/kiwiirccom.vue
+++ b/src/thirdparty/kiwiirccom.vue
@@ -6,6 +6,7 @@
         <p>{{ $t('personal_return') }}</p>
 
         <button
+            type="button"
             class="u-button u-button-primary"
             @click="addNetwork"
         >


### PR DESCRIPTION
in Firefox button elements without type attribute that are a child of `<form>` behave as a submit button

fix by ensuring all button elements have a type attribute defined

closes #1425