### PR TITLE
Fix syntax of bold and italic being improperly swapped

### DIFF
--- a/src/libs/MessageFormatter.js
+++ b/src/libs/MessageFormatter.js
@@ -49,14 +49,14 @@ tokens['*'] = {
     extra: true,
     fn: function parseToken(inp, pos, block, prevBlock, openToks) {
         if (openToks[this.token]) {
-            delete block.styles.bold;
+            delete block.styles.italic;
             openToks[this.token] = null;
             prevBlock.content += this.token;
             return null;
         }
 
         // If this style is alrady open by something else, ignore it
-        if (block.styles.bold === true) {
+        if (block.styles.italic === true) {
             return -1;
         }
 
@@ -84,7 +84,7 @@ tokens['*'] = {
         }
 
         openToks[this.token] = true;
-        block.styles.bold = true;
+        block.styles.italic = true;
         block.content += this.token;
 
         return null;
@@ -95,14 +95,14 @@ tokens['**'] = {
     extra: true,
     fn: function parseToken(inp, pos, block, prevBlock, openToks) {
         if (openToks[this.token]) {
-            delete block.styles.italic;
+            delete block.styles.bold;
             openToks[this.token] = null;
             prevBlock.content += this.token;
             return null;
         }
 
         // If this style is alrady open by something else, ignore it
-        if (block.styles.italic === true) {
+        if (block.styles.bold === true) {
             return -1;
         }
 
@@ -112,7 +112,7 @@ tokens['**'] = {
         }
 
         openToks[this.token] = true;
-        block.styles.italic = true;
+        block.styles.bold = true;
         block.content += this.token;
 
         return null;


### PR DESCRIPTION
In every other markdown implementation (regularmarkdown, discord, github and many others) \* means *italic* and \*\* means **bold**.

Them being improperly swapped makes using formatting very confusing and cumbersome for many users

https://www.markdownguide.org/
https://support.discord.com/hc/en-us/articles/210298617-Markdown-Text-101-Chat-Formatting-Bold-Italic-Underline-
https://github.github.com/gfm/
https://rmarkdown.rstudio.com/