### PR TITLE
fix chathistory 005 token name

### DIFF
--- a/src/libs/ChathistoryMiddleware.js
+++ b/src/libs/ChathistoryMiddleware.js
@@ -50,7 +50,7 @@ function addFunctionsToClient(client) {
         },
     };
 
-    history.isSupported = () => !!client.network.supports('draft/chathistory');
+    history.isSupported = () => !!client.network.supports('chathistory');
 
     history.before = (target, dateOrTime) => new Promise((resolve) => {
         if (!history.isSupported()) {


### PR DESCRIPTION
This is a bug introduced in https://github.com/kiwiirc/kiwiirc/pull/1244 ; Kiwi was modified to use a draft prefix for both the capability name and the 005 token, but only the capability name was modified on the spec side. Since the latest Ergo release now publishes the correct token name, use that name unconditionally.

I tested this against the Ergo testnet: [https://testnet.ergo.chat/kiwi__](https://testnet.ergo.chat/kiwi__) and it seems to work. Soju publishes the correct token. I'm not sure if there are any non-Ergo implementations that are currently publishing the incorrect token?