### PR TITLE
Allow showing avatars when there is no message.user object

### DIFF
--- a/src/components/MessageListMessageModern.vue
+++ b/src/components/MessageListMessageModern.vue
@@ -207,7 +207,7 @@ const methods = {
     displayAvatar(message) {
         let props = this.props;
         // if there is no user attached hide the avatar
-        if (!message.user) {
+        if (!message.user && !props.ml.buffer.state.setting('avatars.show_without_user')) {
             return false;
         }
 

--- a/src/res/configTemplates.js
+++ b/src/res/configTemplates.js
@@ -94,6 +94,7 @@ export const configTemplates = {
             away_status_position: 1,
             initials_length: 1,
             show_image_background: true,
+            show_without_user: false,
         },
         // Startup screen default
         startupOptions: {


### PR DESCRIPTION
config option: `avatars.show_without_user`

closes: #1889