### PR TITLE
Better formatting of unknown commands

### DIFF
--- a/src/libs/IrcClient.js
+++ b/src/libs/IrcClient.js
@@ -363,10 +363,7 @@ function clientMiddleware(state, network) {
                     buffer.enabled = false;
                 }
             } else {
-                // Only show non-numeric commands
-                if (!event.command.match(/^\d+$/)) {
-                    message += event.command + ' ';
-                }
+                message = '\x02' + event.command + '\x02 ' + message;
 
                 state.addMessage(buffer, {
                     time: eventTime,


### PR DESCRIPTION
This puts the command at the start of the line in bold.

currently its at the end of the line with the space after, making it look like it part of the last param