### PR TITLE
feat: implement IRCv3 echo-message capability

### DIFF
--- a/src/libs/InputHandler.js
+++ b/src/libs/InputHandler.js
@@ -188,7 +188,11 @@ function handleMessage(type, event, command, line, context) {
             type: type,
         };
 
-        this.state.addMessage(buffer, newMessage);
+        // When echo-message is active the server will echo our message back,
+        // so skip the local echo to avoid displaying the message twice.
+        if (!network.ircClient.network.cap.isEnabled('echo-message')) {
+            this.state.addMessage(buffer, newMessage);
+        }
     }
 
     let fnNames = {

--- a/src/libs/IrcClient.js
+++ b/src/libs/IrcClient.js
@@ -19,6 +19,7 @@ export function create(state, network) {
         message_max_length: 350,
     });
     ircClient.requestCap('znc.in/self-message');
+    ircClient.requestCap('echo-message');
     ircClient.use(chathistoryMiddleware());
     ircClient.use(clientMiddleware(state, network));
     ircClient.use(typingMiddleware());

--- a/tests/unit/EchoMessage.spec.js
+++ b/tests/unit/EchoMessage.spec.js
@@ -1,0 +1,118 @@
+'kiwi public';
+
+import InputHandler from '@/libs/InputHandler';
+
+function makeCapStub(enabledCaps) {
+    return {
+        isEnabled: (cap) => enabledCaps.includes(cap),
+    };
+}
+
+function makeNetwork(capStub, ircClientSay) {
+    return {
+        id: 1,
+        nick: 'testnick',
+        isChannelName: (name) => name.startsWith('#'),
+        connection: { server: 'irc.example.com' },
+        ircClient: {
+            network: {
+                cap: capStub,
+                extractTargetGroup: () => null,
+            },
+            say: ircClientSay || jest.fn(),
+            notice: jest.fn(),
+            action: jest.fn(),
+        },
+        setting: () => undefined,
+    };
+}
+
+function makeBuffer(name) {
+    return {
+        name,
+        isServer: () => false,
+        isChannel: () => name.startsWith('#'),
+    };
+}
+
+function makeState(addMessageSpy) {
+    const listeners = {};
+    const watchers = [];
+
+    return {
+        addMessage: addMessageSpy,
+        getOrAddBufferByName: (networkId, name) => makeBuffer(name),
+        getBufferByName: () => null,
+        getActiveNetwork: () => null,
+        getActiveBuffer: () => null,
+        setting: (key) => {
+            if (key === 'aliases') return '';
+            return undefined;
+        },
+        $on: (event, fn) => {
+            listeners[event] = fn;
+        },
+        $emit: (event, ...args) => {
+            if (listeners[event]) listeners[event](...args);
+        },
+        $watch: () => {},
+    };
+}
+
+describe('echo-message deduplication in InputHandler', () => {
+    it('adds the message locally when echo-message cap is not active', () => {
+        const addMessage = jest.fn();
+        const state = makeState(addMessage);
+        const cap = makeCapStub([]);
+        const network = makeNetwork(cap);
+        const buffer = makeBuffer('#channel');
+
+        const handler = new InputHandler(state);
+
+        handler.processLine('/msg #channel hello', { network, buffer });
+
+        expect(addMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not add the message locally when echo-message cap is active', () => {
+        const addMessage = jest.fn();
+        const state = makeState(addMessage);
+        const cap = makeCapStub(['echo-message']);
+        const network = makeNetwork(cap);
+        const buffer = makeBuffer('#channel');
+
+        const handler = new InputHandler(state);
+
+        handler.processLine('/msg #channel hello', { network, buffer });
+
+        expect(addMessage).not.toHaveBeenCalled();
+    });
+
+    it('adds notices locally when echo-message cap is not active', () => {
+        const addMessage = jest.fn();
+        const state = makeState(addMessage);
+        const cap = makeCapStub([]);
+        const network = makeNetwork(cap);
+        const buffer = makeBuffer('#channel');
+
+        const handler = new InputHandler(state);
+
+        handler.processLine('/notice #channel hello', { network, buffer });
+
+        expect(addMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not add notices locally when echo-message cap is active', () => {
+        const addMessage = jest.fn();
+        const state = makeState(addMessage);
+        const cap = makeCapStub(['echo-message']);
+        const network = makeNetwork(cap);
+        const buffer = makeBuffer('#channel');
+
+        const handler = new InputHandler(state);
+
+        handler.processLine('/notice #channel hello', { network, buffer });
+
+        expect(addMessage).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary

This PR implements support for the [IRCv3 echo-message](https://ircv3.net/specs/extensions/echo-message) capability.

## What echo-message does

When a client requests and the server grants `echo-message`, the server echoes every `PRIVMSG` and `NOTICE` the client sends back to that same client. This gives the client an authoritative acknowledgement that the message was delivered (and shows the final, possibly server-modified text).

## Changes

### `src/libs/IrcClient.js`
- Request the `echo-message` capability alongside the existing `znc.in/self-message` request.

### `src/libs/InputHandler.js`
- When `echo-message` is active, skip the local optimistic echo of sent messages. The server echo arrives through the normal `message` event handler and is displayed instead, preventing the message from appearing twice.
- No change in behaviour on servers that do not support `echo-message`.

### `tests/unit/EchoMessage.spec.js`
- New unit tests verifying that messages are echoed locally when the cap is absent and suppressed locally when the cap is active, for both `PRIVMSG` and `NOTICE`.

## Testing

All 76 existing tests continue to pass plus the 4 new ones:

```
PASS  tests/unit/EchoMessage.spec.js
  echo-message deduplication in InputHandler
    + adds the message locally when echo-message cap is not active
    + does not add the message locally when echo-message cap is active
    + adds notices locally when echo-message cap is not active
    + does not add notices locally when echo-message cap is active
```