### PR TITLE
feat: extend /ignore to block TAGMSG

### DIFF
--- a/src/libs/IgnoreMiddleware.js
+++ b/src/libs/IgnoreMiddleware.js
@@ -1,0 +1,18 @@
+'kiwi public';
+
+export default function ignoreMiddleware(network) {
+    const FILTERED = new Set(['PRIVMSG', 'NOTICE', 'TAGMSG']);
+    return function middleware(client, rawEvents /* , parsedEvents */) {
+        rawEvents.use((command, message, rawLine, c, next) => {
+            if (!message || !message.nick || !FILTERED.has(command)) {
+                next();
+                return;
+            }
+            const lower = message.nick.toLowerCase();
+            const ignored = network.ignored_list.some((n) => n.toLowerCase() === lower);
+            if (!ignored) {
+                next();
+            }
+        });
+    };
+}

--- a/src/libs/IrcClient.js
+++ b/src/libs/IrcClient.js
@@ -6,6 +6,7 @@ import Irc from 'irc-framework';
 import * as TextFormatting from '@/helpers/TextFormatting';
 import typingMiddleware from './TypingMiddleware';
 import chathistoryMiddleware from './ChathistoryMiddleware';
+import ignoreMiddleware from './IgnoreMiddleware';
 import * as ServerConnection from './ServerConnection';
 
 export function create(state, network) {
@@ -19,6 +20,7 @@ export function create(state, network) {
         message_max_length: 350,
     });
     ircClient.requestCap('znc.in/self-message');
+    ircClient.use(ignoreMiddleware(network));
     ircClient.use(chathistoryMiddleware());
     ircClient.use(clientMiddleware(state, network));
     ircClient.use(typingMiddleware());


### PR DESCRIPTION
Current /ignore is sooo IRCv2.
IRCv3 TAGMSG messages bypassed the ignore filter entirely, causing empty private query buffers to open for ignored users.
A new rawEvents middleware drops PRIVMSG/NOTICE/TAGMSG from any nick in ignored_list before irc.raw.* events are emitted, so typing indicators or game plugins never create buffers and are never shown.