### PR TITLE
Update i18n labels with new plural format

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -398,7 +398,6 @@ function initLocales() {
     i18next.use(i18nextHTTP);
     i18next.init({
         supportedLngs: AvailableLocales.locales,
-        compatibilityJSON: 'v3',
         fallbackLng: 'en-us',
         lowerCaseLng: true,
         backend: {

--- a/src/res/locales/app.af-ZA.po
+++ b/src/res/locales/app.af-ZA.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Preview"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} week"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} weeks"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} day"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} days"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "{{count}} hour"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} hours"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "{{count}} minute"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} minutes"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} second"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} seconds"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "Verwyder netwerk"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} persoon hier"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} mense hier"
 
 #: Filter users in channel

--- a/src/res/locales/app.ar-SA.po
+++ b/src/res/locales/app.ar-SA.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "معاينة"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} أسبوع"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} أسبوع"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} يوم"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} يوم"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "{{count}} ساعة"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} ساعة"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "{{count}} دقيقة"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} دقيقة"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} ثانية"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} ثانية"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "حذف الشبكه"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} شخص هنا"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} أشخاص هنا"
 
 #: Filter users in channel

--- a/src/res/locales/app.bg-BG.po
+++ b/src/res/locales/app.bg-BG.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Preview"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} седмица"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} седмици"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} ден"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} дни"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "{{count}} час"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} часа"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "{{count}} минута"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} минути"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} секунда"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} секунди"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "Премахване на мрежата"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} човек тук"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} души тук"
 
 #: Filter users in channel

--- a/src/res/locales/app.bs-BA.po
+++ b/src/res/locales/app.bs-BA.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Preview"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} sedmica"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} sedmica"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} dan"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} dana"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "{{count}} sat"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} sati"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "{{count}} minuta"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} minuta"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} sekunda"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} sekundi"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "Ukloni mrežu"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} dostupna osoba"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} dostupnih osoba"
 
 #: Filter users in channel

--- a/src/res/locales/app.ca-ES.po
+++ b/src/res/locales/app.ca-ES.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Preview"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} setmana"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} setmanes"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} dia"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} dies"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "{{count}} hora"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} hores"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "{{count}} minut"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} minuts"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} segon"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} segons"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "Eliminar xarxa"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} usuari aquí"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} usuaris aquí"
 
 #: Filter users in channel

--- a/src/res/locales/app.cs-CZ.po
+++ b/src/res/locales/app.cs-CZ.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Preview"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} week"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} weeks"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} day"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} days"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "{{count}} hour"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} hours"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "{{count}} minute"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} minutes"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} second"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} seconds"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "Remove network"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} person here"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} people here"
 
 #: Filter users in channel

--- a/src/res/locales/app.da-DK.po
+++ b/src/res/locales/app.da-DK.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Preview"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} week"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} weeks"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} day"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} days"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "{{count}} hour"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} hours"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "{{count}} minute"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} minutes"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} second"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} seconds"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "Remove network"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} person here"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} people here"
 
 #: Filter users in channel

--- a/src/res/locales/app.de-DE.po
+++ b/src/res/locales/app.de-DE.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Vorschau"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} Woche"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} Wochen"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} Tag"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} Tage"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "{{count}} Stunde"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} Stunden"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "{{count}} Minute"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} Minuten"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} Sekunde"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} Sekunden"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "Entferne Netzwerk"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} user online"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} user hier"
 
 #: Filter users in channel

--- a/src/res/locales/app.dev.po
+++ b/src/res/locales/app.dev.po
@@ -217,43 +217,43 @@ msgstr "Preview"
 #: Durations
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} week"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} weeks"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} day"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} days"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "{{count}} hour"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} hours"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "{{count}} minute"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} minutes"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} second"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} seconds"
 
 
@@ -714,11 +714,11 @@ msgstr "Remove network"
 #: Nicklist
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} person here"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} people here"
 
 #: Filter users in channel

--- a/src/res/locales/app.el-GR.po
+++ b/src/res/locales/app.el-GR.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Προεπισκόπιση"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} εβδομάδα"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} εβδομάδες"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} ημέρα"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} ημέρες"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "{{count}} ώρα"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} ώρες"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "{{count}} λεπτό"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} λεπτά"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} δευτερόλεπτο"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} δευτερόλεπτα"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "Κατάργηση δικτύου"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} άτομο εδώ"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} άτομα εδώ"
 
 #: Filter users in channel

--- a/src/res/locales/app.en-US.po
+++ b/src/res/locales/app.en-US.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Preview"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} week"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} weeks"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} day"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} days"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "{{count}} hour"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} hours"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "{{count}} minute"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} minutes"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} second"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} seconds"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "Remove network"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} person here"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} people here"
 
 #: Filter users in channel

--- a/src/res/locales/app.es-419.po
+++ b/src/res/locales/app.es-419.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Preview"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "semana"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "semanas"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "día"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "días"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "hora"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "horas"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "minuto"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "minutos"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "segundo"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "segundos"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "Eliminar red"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} persona aquí"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} personas aquí"
 
 #: Filter users in channel

--- a/src/res/locales/app.es-AR.po
+++ b/src/res/locales/app.es-AR.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Preview"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "semana"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "semanas"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "día"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "días"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "hora"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "horas"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "minuto"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "minutos"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "segundo"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "segundos"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "Eliminar red"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} usuario aquí"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} usuarios aquí"
 
 #: Filter users in channel

--- a/src/res/locales/app.es-EM.po
+++ b/src/res/locales/app.es-EM.po
@@ -343,11 +343,11 @@ msgid "settings_remove"
 msgstr "Eliminar red"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} usuario aquí"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} usuarios aquí"
 
 #: Reconnect to join {{channel}}

--- a/src/res/locales/app.es-ES.po
+++ b/src/res/locales/app.es-ES.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Preview"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} semana"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} semanas"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} día"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} días"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "{{count}} hora"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} horas"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "{{count}} minuto"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} minutos"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} segundo"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} segundos"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "Eliminar red"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} usuario aquí"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} usuarios aquí"
 
 #: Filter users in channel

--- a/src/res/locales/app.es-US.po
+++ b/src/res/locales/app.es-US.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Preview"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "semana"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "semanas"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "día"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "días"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "hora"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "horas"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "minuto"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "minutos"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "segundo"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "segundos"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "Eliminar red"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} usuario aquí"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} usuarios aquí"
 
 #: Filter users in channel

--- a/src/res/locales/app.eu-ES.po
+++ b/src/res/locales/app.eu-ES.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Preview"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "aste {{count}} "
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} aste"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "egun {{count}}"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} egun"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "ordu {{count}}"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} ordu"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "minutu {{count}}"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} minutu"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "segundo {{count}}"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} ssegundoak"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "Sarea ezabatzea"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "Hemen {{count}} erabiltzaile"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr " {{count}} erabiltzaile"
 
 #: Filter users in channel

--- a/src/res/locales/app.fi-FI.po
+++ b/src/res/locales/app.fi-FI.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Preview"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "viikko"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "week_plural"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "päivä"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "day_plural"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "tunti"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "hour_plural"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "minuutti"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "minute_plural"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "toinen"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "second_plural"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "settings_remove"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "henkilö"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "person_plural"
 
 #: Filter users in channel

--- a/src/res/locales/app.fr-FR.po
+++ b/src/res/locales/app.fr-FR.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Preview"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} semaine"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} semaines"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} jour"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} jours"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "{{count}} heure"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} heures"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "{{count}} minute"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} minutes"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} seconde"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} secondes"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "Supprimer le réseau"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} membre ici"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} membres ici"
 
 #: Filter users in channel

--- a/src/res/locales/app.gl-ES.po
+++ b/src/res/locales/app.gl-ES.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Preview"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} semana"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} semanas"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} día"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} días"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "{{count}} hora"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} horas"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "{{count}} minuto"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} minutos"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} segundo"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} segundos"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "Eliminar rede"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} usuario aquí"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} usuarios aquí"
 
 #: Filter users in channel

--- a/src/res/locales/app.he-IL.po
+++ b/src/res/locales/app.he-IL.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "תצוגה מקדימה"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} week"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} weeks"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} day"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} days"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "{{count}} hour"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} hours"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "{{count}} minute"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} minutes"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} second"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} seconds"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "הסר רשת"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} נוכחים"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} אנשים כאן"
 
 #: Filter users in channel

--- a/src/res/locales/app.hi-IN.po
+++ b/src/res/locales/app.hi-IN.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Preview"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{Ginti}} Kamzor"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "#: {{count}} saptah"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "Din"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "#:{{count}} Dino"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "#:{{count}} ghanta"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "#: {{count}} ghante"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "#:{{count}} minute"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "#:{{count}} minto"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "#:{{count}} second"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "#:{{count}} seconds"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "#: Network Hataye"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "#: {{count}} Yaha ke Log"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "#: {{count}} yaha ke log"
 
 #: Filter users in channel

--- a/src/res/locales/app.hu-HU.po
+++ b/src/res/locales/app.hu-HU.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Preview"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "hét"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} weeks"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "nap"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} days"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "óra"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} hours"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "perc"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} minutes"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "másodperc"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} seconds"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "Hálózat eltávolítása"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "személy"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} people here"
 
 #: Filter users in channel

--- a/src/res/locales/app.id-ID.po
+++ b/src/res/locales/app.id-ID.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Preview"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} pekan"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} pekan"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} hari"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} hari"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "{{count}} jam"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} jam"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "{{count}} menit"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} menit"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} detik"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} detik"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "Hapus jejaring"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} orang di sini"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} orang di sini"
 
 #: Filter users in channel

--- a/src/res/locales/app.it-IT.po
+++ b/src/res/locales/app.it-IT.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Preview"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} settimana"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} settimane"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} giorno"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} giorni"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "{{count}} ora"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} ore"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "{{count}} minuto"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} minuti"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} secondo"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} secondi"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "Rimuovi rete"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} persona qui"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} persone qui"
 
 #: Filter users in channel

--- a/src/res/locales/app.ja-JP.po
+++ b/src/res/locales/app.ja-JP.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Preview"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} week"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} weeks"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} day"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} days"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "時"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "時"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "分"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "分"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} second"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} seconds"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "Remove network"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} person here"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} people here"
 
 #: Filter users in channel

--- a/src/res/locales/app.ko-KR.po
+++ b/src/res/locales/app.ko-KR.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Preview"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} 주"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} 주"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} 일"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} 일"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "{{count}} 시간"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} 시간"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "{{count}}분"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} 분"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} 초"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} 초"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "네트워크 삭제"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}}명의 사람이 존재함"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}}명의 사람이 존재함"
 
 #: Filter users in channel

--- a/src/res/locales/app.nl-NL.po
+++ b/src/res/locales/app.nl-NL.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Preview"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} week"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} weken"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} dag"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} dagen"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "{{count}} uur"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} uur"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "{{count}} minuut"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} minuten"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} seconde"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} seconden"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "Netwerk verwijderen"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} persoon aanwezig"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} personen aanwezig"
 
 #: Filter users in channel

--- a/src/res/locales/app.no-NO.po
+++ b/src/res/locales/app.no-NO.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Preview"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} week"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} weeks"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} day"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} days"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "{{count}} hour"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} hours"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "{{count}} minute"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} minutes"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} second"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} seconds"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "Remove network"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} person here"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} people here"
 
 #: Filter users in channel

--- a/src/res/locales/app.pl-PL.po
+++ b/src/res/locales/app.pl-PL.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Podgląd"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} tydzień"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} tygodni(e)"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} dzień"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} dni"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "{{count}} godzina"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} godzin(y)"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "{{count}} minuta"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} minut(y)"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} sekunda"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} sekund(y)"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "Usuń sieć"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} osoba tutaj"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} osoby/osób tutaj"
 
 #: Filter users in channel

--- a/src/res/locales/app.pt-BR.po
+++ b/src/res/locales/app.pt-BR.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Preview"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} semana"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} semanas"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} dia"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} dias"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "{{count}} hora"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} horas"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "{{count}} minuto"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} minutos"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} segundo"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} segundos"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "Remover rede"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} usuário aqui"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} usuários aqui"
 
 #: Filter users in channel

--- a/src/res/locales/app.pt-PT.po
+++ b/src/res/locales/app.pt-PT.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Preview"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} semana"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} semanas"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} dia"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} dias"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "{{count}} hora"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} horas"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "{{count}} minuto"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} minutos"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} segundo"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} segundos"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "Remover rede"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} pessoa aqui"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} pessoas aqui"
 
 #: Filter users in channel

--- a/src/res/locales/app.ro-RO.po
+++ b/src/res/locales/app.ro-RO.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Preview"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} săptămână"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} săptămâni"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} zi"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} zile"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "{{count}} oră"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} ore"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "{{count}} minut"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} minute"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} secunde"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} secunde"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "Înlătură rețeaua"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} persoane prezente"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} oameni prezenți"
 
 #: Filter users in channel

--- a/src/res/locales/app.ru-RU.po
+++ b/src/res/locales/app.ru-RU.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Предпросмотр"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} неделя"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} недели"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} день"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} дней"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "{{count}} час"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} часов"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "{{count}} минута"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} минут"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} секунд"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} секунды"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "Удалить сеть"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} человек здесь"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} человек здесь"
 
 #: Filter users in channel

--- a/src/res/locales/app.sl-SI.po
+++ b/src/res/locales/app.sl-SI.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Preview"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} week"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} weeks"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} day"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} days"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "{{count}} hour"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} hours"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "{{count}} minute"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} minutes"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} second"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} seconds"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "Remove network"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} person here"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} people here"
 
 #: Filter users in channel

--- a/src/res/locales/app.sq-AL.po
+++ b/src/res/locales/app.sq-AL.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Paraparje"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} javë"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} javë"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} ditë"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} ditë"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "{{count}} orë"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} orë"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "{{count}} minutë"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} minuta"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} sekondë"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} sekonda"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "Hiqe rrjetin"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} person këtu"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} vetë këtu"
 
 #: Filter users in channel

--- a/src/res/locales/app.sr-SP.po
+++ b/src/res/locales/app.sr-SP.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Preview"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} week"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} weeks"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} day"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} days"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "{{count}} hour"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} hours"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "{{count}} minute"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} minutes"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} second"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} seconds"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "Remove network"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} person here"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} people here"
 
 #: Filter users in channel

--- a/src/res/locales/app.sv-SE.po
+++ b/src/res/locales/app.sv-SE.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Preview"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} vecka"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} veckor"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} dag"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} dagar"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "{{count}} timme"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} timmar"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "{{count}} minut"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} minuter"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} sekund"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} sekunder"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "Remove network"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} person here"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} people here"
 
 #: Filter users in channel

--- a/src/res/locales/app.tr-TR.po
+++ b/src/res/locales/app.tr-TR.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Preview"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} hafta"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} hafta"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} gün"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} gün"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "{{count}} saat"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} saat"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "{{count}} dakika"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} dakika"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} saniye"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} saniye"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "Ağı kaldır"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} kişi burada"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} kişi burada"
 
 #: Filter users in channel

--- a/src/res/locales/app.uk-UA.po
+++ b/src/res/locales/app.uk-UA.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Preview"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} тиждень"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} тижнів"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} день"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} днів"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "{{count}} година"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} годин"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "{{count}} хвилина"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} хвилин"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} секунда"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} секунд"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "Вилучити мережу"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "Тут {{count}} людина"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "Тут {{count}} людей"
 
 #: Filter users in channel

--- a/src/res/locales/app.vi-VN.po
+++ b/src/res/locales/app.vi-VN.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Preview"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} week"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} weeks"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} day"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} days"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "{{count}} hour"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} hours"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "{{count}} minute"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} minutes"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} second"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} seconds"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "Remove network"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} person here"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} people here"
 
 #: Filter users in channel

--- a/src/res/locales/app.zh-CN.po
+++ b/src/res/locales/app.zh-CN.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Preview"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} 个星期"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} 周"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} 天"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} 天"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "{{count}} 小时"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} 小时"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "{{count}} 分钟"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} 分钟"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} 秒"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} 秒"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "移除网络"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "有 {{count}} 人在线"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "有 {{count}} 人在线"
 
 #: Filter users in channel

--- a/src/res/locales/app.zh-TW.po
+++ b/src/res/locales/app.zh-TW.po
@@ -220,43 +220,43 @@ msgid "preview"
 msgstr "Preview"
 
 #: {{count}} week
-msgid "week"
+msgid "week_one"
 msgstr "{{count}} 週"
 
 #: {{count}} weeks
-msgid "week_plural"
+msgid "week_other"
 msgstr "{{count}} 週"
 
 #: {{count}} day
-msgid "day"
+msgid "day_one"
 msgstr "{{count}} 天"
 
 #: {{count}} days
-msgid "day_plural"
+msgid "day_other"
 msgstr "{{count}} 天"
 
 #: {{count}} hour
-msgid "hour"
+msgid "hour_one"
 msgstr "{{count}} 小時"
 
 #: {{count}} hours
-msgid "hour_plural"
+msgid "hour_other"
 msgstr "{{count}} 小時"
 
 #: {{count}} minute
-msgid "minute"
+msgid "minute_one"
 msgstr "{{count}} 分鐘"
 
 #: {{count}} minutes
-msgid "minute_plural"
+msgid "minute_other"
 msgstr "{{count}} 分鐘"
 
 #: {{count}} second
-msgid "second"
+msgid "second_one"
 msgstr "{{count}} 秒"
 
 #: {{count}} seconds
-msgid "second_plural"
+msgid "second_other"
 msgstr "{{count}} 秒"
 
 #: General
@@ -664,11 +664,11 @@ msgid "settings_remove"
 msgstr "移除網路"
 
 #: {{count}} person here
-msgid "person"
+msgid "person_one"
 msgstr "{{count}} person here"
 
 #: {{count}} people here
-msgid "person_plural"
+msgid "person_other"
 msgstr "{{count}} people here"
 
 #: Filter users in channel


### PR DESCRIPTION
i18next changed its format to handle plurals, `_others` (plural) and `_one` (singular) should be used instead now.
In the past with [this](https://github.com/kiwiirc/kiwiirc/blame/master/src/main.js#L401) commit the `compatibilityJSON` was configured to v3 to remain backwards compatible.

However in [this](https://github.com/kiwiirc/kiwiirc/commit/c789328d0f092cf420198eb89ecdc4458a0e8ab4) commit i18next was upgraded from 22.x.x to 25.x.x and in version 24.0.0 support for this was dropped: https://github.com/i18next/i18next/blob/master/CHANGELOG.md#2400