### PR TITLE
feat: reconcile own-message echoes to fix duplicates after reconnect

### DIFF
--- a/src/components/MessageListMessageCompact.vue
+++ b/src/components/MessageListMessageCompact.vue
@@ -26,6 +26,8 @@
             props.ml.message_info_open && props.ml.message_info_open !== props.message
                 ? 'kiwi-messagelist-message--blur'
                 : '',
+            props.message.pending ? 'kiwi-messagelist-message--pending' : '',
+            props.message.send_failed ? 'kiwi-messagelist-message--send-failed' : '',
             (props.message.user && props.m().userMode(props.message.user))
                 ? `kiwi-messagelist-message--user-mode-${props.m().userMode(props.message.user)}`
                 : '',
@@ -85,6 +87,16 @@
             class="kiwi-messagelist-body"
         />
         <div v-else class="kiwi-messagelist-body" v-html="props.ml.formatMessage(props.message)" />
+
+        <div
+            v-if="props.message.send_failed"
+            class="kiwi-messagelist-sendstatus"
+        >
+            {{ props.ml.$t('message_not_sent') }}
+            <a class="u-link" @click.stop="props.m().resendMessage(props.message)">
+                {{ props.ml.$t('message_resend') }}
+            </a>
+        </div>
 
         <component
             :is="injections.components.MessageInfo"
@@ -148,6 +160,10 @@ const methods = {
     userModePrefix(user) {
         let props = this.props;
         return props.ml.buffer.userModePrefix(user);
+    },
+    resendMessage(message) {
+        let props = this.props;
+        props.ml.buffer.getNetwork().pendingMessages.resend(message);
     },
 };
 
@@ -231,6 +247,23 @@ export default {
 
 .kiwi-messagelist-message--compact .kiwi-messageinfo {
     padding-left: 130px;
+}
+
+.kiwi-messagelist-message--compact.kiwi-messagelist-message--pending .kiwi-messagelist-body,
+.kiwi-messagelist-message--compact.kiwi-messagelist-message--send-failed .kiwi-messagelist-body {
+    opacity: 0.55;
+}
+
+.kiwi-messagelist-message--compact .kiwi-messagelist-sendstatus {
+    display: block;
+    margin-left: 120px;
+    font-size: 0.85em;
+    opacity: 0.8;
+}
+
+.kiwi-messagelist-message--compact .kiwi-messagelist-sendstatus .u-link {
+    cursor: pointer;
+    font-weight: 600;
 }
 
 //Channel traffic messages

--- a/src/components/MessageListMessageInline.vue
+++ b/src/components/MessageListMessageInline.vue
@@ -23,6 +23,8 @@
             props.ml.message_info_open && props.ml.message_info_open !== props.message
                 ? 'kiwi-messagelist-message--blur'
                 : '',
+            props.message.pending ? 'kiwi-messagelist-message--pending' : '',
+            props.message.send_failed ? 'kiwi-messagelist-message--send-failed' : '',
             (props.message.user && props.m().userMode(props.message.user))
                 ? `kiwi-messagelist-message--user-mode-${props.m().userMode(props.message.user)}`
                 : '',
@@ -84,6 +86,16 @@
             />
         </div>
 
+        <div
+            v-if="props.message.send_failed"
+            class="kiwi-messagelist-sendstatus"
+        >
+            {{ props.ml.$t('message_not_sent') }}
+            <a class="u-link" @click.stop="props.m().resendMessage(props.message)">
+                {{ props.ml.$t('message_resend') }}
+            </a>
+        </div>
+
         <component
             :is="injections.components.MessageInfo"
             v-if="props.ml.message_info_open === props.message"
@@ -126,6 +138,10 @@ const methods = {
     userModePrefix(user) {
         let props = this.props;
         return props.ml.buffer.userModePrefix(user);
+    },
+    resendMessage(message) {
+        let props = this.props;
+        props.ml.buffer.getNetwork().pendingMessages.resend(message);
     },
 };
 
@@ -208,6 +224,21 @@ export default {
 
 .kiwi-messagelist-message--text .kiwi-messagelist-body a {
     word-break: break-all;
+}
+
+.kiwi-messagelist-message--text.kiwi-messagelist-message--pending .kiwi-messagelist-body,
+.kiwi-messagelist-message--text.kiwi-messagelist-message--send-failed .kiwi-messagelist-body {
+    opacity: 0.55;
+}
+
+.kiwi-messagelist-message--text .kiwi-messagelist-sendstatus {
+    font-size: 0.85em;
+    opacity: 0.8;
+}
+
+.kiwi-messagelist-message--text .kiwi-messagelist-sendstatus .u-link {
+    cursor: pointer;
+    font-weight: 600;
 }
 
 .kiwi-messagelist-message--text .kiwi-messagelist-message-privmsg:hover,

--- a/src/components/MessageListMessageModern.vue
+++ b/src/components/MessageListMessageModern.vue
@@ -26,6 +26,8 @@
             props.ml.message_info_open && props.ml.message_info_open !== props.message
                 ? 'kiwi-messagelist-message--blur'
                 : '',
+            props.message.pending ? 'kiwi-messagelist-message--pending' : '',
+            props.message.send_failed ? 'kiwi-messagelist-message--send-failed' : '',
             (props.message.user && props.m().userMode(props.message.user))
                 ? `kiwi-messagelist-message--user-mode-${props.m().userMode(props.message.user)}`
                 : '',
@@ -109,6 +111,16 @@
                 class="kiwi-messagelist-body"
                 v-html="props.ml.formatMessage(props.message)"
             />
+
+            <div
+                v-if="props.message.send_failed"
+                class="kiwi-messagelist-sendstatus"
+            >
+                {{ props.ml.$t('message_not_sent') }}
+                <a class="u-link" @click.stop="props.m().resendMessage(props.message)">
+                    {{ props.ml.$t('message_resend') }}
+                </a>
+            </div>
 
             <component
                 :is="injections.components.MessageInfo"
@@ -235,6 +247,10 @@ const methods = {
     userModePrefix(user) {
         let props = this.props;
         return props.ml.buffer.userModePrefix(user);
+    },
+    resendMessage(message) {
+        let props = this.props;
+        props.ml.buffer.getNetwork().pendingMessages.resend(message);
     },
 };
 
@@ -369,6 +385,25 @@ export default {
 .kiwi-messagelist-message--modern .kiwi-messagelist-nick {
     padding: 0;
     margin-right: 10px;
+}
+
+.kiwi-messagelist-message--pending .kiwi-messagelist-body {
+    opacity: 0.55;
+}
+
+.kiwi-messagelist-message--send-failed .kiwi-messagelist-body {
+    opacity: 0.55;
+}
+
+.kiwi-messagelist-sendstatus {
+    font-size: 0.85em;
+    margin-bottom: 10px;
+    opacity: 0.8;
+}
+
+.kiwi-messagelist-sendstatus .u-link {
+    cursor: pointer;
+    font-weight: 600;
 }
 
 .kiwi-messagelist-message-traffic .kiwi-messagelist-body {

--- a/src/libs/InputHandler.js
+++ b/src/libs/InputHandler.js
@@ -169,26 +169,13 @@ function handleMessage(type, event, command, line, context) {
 
     let buffer = localBuffer.length && this.state.getOrAddBufferByName(network.id, localBuffer);
     if (buffer) {
-        let textFormatType = 'privmsg';
-        if (type === 'action') {
-            textFormatType = 'action';
-        } else if (type === 'notice') {
-            textFormatType = 'notice';
-        }
-
-        let messageBody = TextFormatting.formatText(textFormatType, {
-            nick: network.nick,
-            text: message,
-        });
-
-        let newMessage = {
-            time: Date.now(),
-            nick: network.nick,
-            message: messageBody,
+        // Renders the message optimistically, sends it (with a label when the server
+        // supports labeled-response) and tracks it for echo reconciliation + manual resend
+        network.pendingMessages.sendAndTrack(buffer, message, {
             type: type,
-        };
-
-        this.state.addMessage(buffer, newMessage);
+            targetName: bufferName,
+        });
+        return;
     }
 
     let fnNames = {
@@ -226,12 +213,7 @@ inputCommands.dice = function inputCommandDice(event, command, line, context) {
         sides: TextFormatting.formatNumber(sides),
         number: TextFormatting.formatNumber(rndNumber),
     });
-    network.ircClient.action(buffer.name, msg);
-    this.state.addMessage(buffer, {
-        nick: network.nick,
-        message: msg,
-        type: 'action',
-    });
+    network.pendingMessages.sendAndTrack(buffer, msg, { type: 'action' });
 };
 
 inputCommands.ctcp = function inputCommandCtcp(event, command, line, context) {

--- a/src/libs/IrcClient.js
+++ b/src/libs/IrcClient.js
@@ -4,6 +4,7 @@ import _ from 'lodash';
 import strftime from 'strftime';
 import Irc from 'irc-framework';
 import * as TextFormatting from '@/helpers/TextFormatting';
+import PendingMessages from './PendingMessages';
 import typingMiddleware from './TypingMiddleware';
 import chathistoryMiddleware from './ChathistoryMiddleware';
 import * as ServerConnection from './ServerConnection';
@@ -19,9 +20,19 @@ export function create(state, network) {
         message_max_length: 350,
     });
     ircClient.requestCap('znc.in/self-message');
+    // echo-message + labeled-response let us reconcile the server's echo of our own
+    // messages onto the optimistically rendered copy (see PendingMessages)
+    ircClient.requestCap(['echo-message', 'labeled-response']);
     ircClient.use(chathistoryMiddleware());
     ircClient.use(clientMiddleware(state, network));
     ircClient.use(typingMiddleware());
+
+    // Tracks optimistically rendered outgoing messages for echo reconciliation and manual
+    // resend. Non-enumerable so it stays out of Vue reactivity and state persistence.
+    Object.defineProperty(network, 'pendingMessages', {
+        writable: true,
+        value: new PendingMessages(network),
+    });
 
     // Overload the connect() function to make sure we are connecting with the
     // most recent connection details from the network state
@@ -170,6 +181,10 @@ function clientMiddleware(state, network) {
             isRegistered = false;
             network.state = 'disconnected';
 
+            // Any message still waiting for its server echo will never get one on this
+            // connection - flag them as failed so the user can manually resend them.
+            network.pendingMessages.failAll();
+
             if (err) {
                 network.state_error = (typeof err === 'string') ? err : 'err_unknown';
             }
@@ -305,6 +320,15 @@ function clientMiddleware(state, network) {
             }
         }
 
+        // labeled-response ACK: the server completes a labeled command that produces no
+        // other response (eg. kiwibnc when the upstream cannot carry our label, or for
+        // *bnc-handled messages). Resolve the matching pending message and keep the ACK
+        // out of the server tab.
+        if (command === 'unknown command' && event.command === 'ACK') {
+            network.pendingMessages.handleAck(event.tags && event.tags.label);
+            return;
+        }
+
         // Show unhandled data from the server in the servers tab
         if (command === 'unknown command') {
             let buffer = network.serverBuffer();
@@ -426,6 +450,14 @@ function clientMiddleware(state, network) {
                 event.message[0] === '['
             ) {
                 bufferName = event.message.substr(1, event.message.indexOf(']') - 1);
+            }
+
+            // Our own messages coming back to us - either echoed live (echo-message) or
+            // replayed from history after a reconnect - may correspond to a message we
+            // already rendered when sending it. Reconcile those onto the existing message
+            // instead of adding a duplicate.
+            if (network.pendingMessages.reconcile(event, bufferName)) {
+                return;
             }
 
             // Notices from somewhere when we don't have an existing buffer for them should go into

--- a/src/libs/Message.js
+++ b/src/libs/Message.js
@@ -53,6 +53,12 @@ export default class Message {
         def(this, 'bodyTemplateProps', message.bodyTemplateProps || {});
         def(this, 'isHighlight', false);
 
+        // Outgoing message states (enumerable so Vue makes them reactive):
+        // pending = sent but not yet acknowledged by the server echo
+        // send_failed = no acknowledgement arrived (connection lost / timeout)
+        this.pending = !!message.pending;
+        this.send_failed = false;
+
         // We don't want the user object to be enumerable
         def(this, 'user', user || null);
 

--- a/src/libs/PendingMessages.js
+++ b/src/libs/PendingMessages.js
@@ -232,10 +232,18 @@ export default class PendingMessages {
         return true;
     }
 
-    // Content-based fallback used when the echo carries no (known) label: only our own
-    // messages with a server msgid, matching exactly one tracked entry by buffer, type and
-    // text. Each entry is consumed at most once, so repeated identical messages ("hi", "hi")
-    // are never over-deduplicated.
+    // Content-based reconciliation. This is the PRIMARY path in practice: InspIRCd does
+    // not return the labeled-response label on echo-message echoes (proven on v3 and v4),
+    // so the label path only ever fires on spec-compliant servers (Ergo/Oragono). We match
+    // our own echo by nick + type + content and graft the server msgid.
+    //
+    // Buffer is deliberately NOT required: on InspIRCd the echo can resolve to a different
+    // buffer name than where we optimistically rendered it, and requiring a buffer match
+    // caused misses. When several pending sends share the same content, a same-buffer entry
+    // is preferred (so identical messages to two channels graft onto the right copy);
+    // otherwise the earliest-inserted entry wins, which gives FIFO consumption for rapid
+    // duplicates (N identical sends reconcile against N echoes without double-grafting) and
+    // lets reordered multi-line echoes each match independently.
     matchHeuristic(event, bufferName) {
         let client = this.network.ircClient;
         // Deliberate: a msgid is required. Without one there is no replay-dedup benefit to
@@ -249,21 +257,20 @@ export default class PendingMessages {
             return null;
         }
 
-        return this.entries.find((entry) => {
-            if (entry.type !== event.type) {
-                return false;
-            }
-            if (entry.rawText !== event.message) {
-                return false;
-            }
-            if (!client.caseCompare(entry.bufferName, bufferName || '')) {
-                return false;
-            }
-            // Pending entries are recent by definition (SEND_TIMEOUT). Failed entries stay
-            // matchable with no time limit: a history replay confirming an old "failed"
-            // message proves it actually reached the server.
-            return true;
-        }) || null;
+        // entries is insertion-ordered, so filter+find both keep FIFO order. Pending entries
+        // are recent (SEND_TIMEOUT); failed entries stay matchable with no time limit so a
+        // history replay confirming an old "failed" message proves it reached the server.
+        let candidates = this.entries.filter(
+            (entry) => entry.type === event.type && entry.rawText === event.message
+        );
+        if (candidates.length === 0) {
+            return null;
+        }
+
+        let sameBuffer = candidates.find(
+            (entry) => client.caseCompare(entry.bufferName, bufferName || '')
+        );
+        return sameBuffer || candidates[0];
     }
 
     graft(entry, event) {

--- a/src/libs/PendingMessages.js
+++ b/src/libs/PendingMessages.js
@@ -1,0 +1,328 @@
+'kiwi public';
+
+import * as TextFormatting from '@/helpers/TextFormatting';
+
+// How long we wait for the server echo before flagging a message as not sent
+const SEND_TIMEOUT_MS = 30000;
+
+// Safety cap so unresolved entries can never grow unbounded
+const MAX_ENTRIES = 200;
+
+// How long an acked entry stays graftable. In the heuristic regime the unlabeled echo
+// follows the ACK within seconds; after this window the entry is just leftover memory.
+// Failed entries are deliberately never expired - the resend UI relies on them.
+const ACKED_TTL_MS = 60000;
+
+let nextLabelNum = 1;
+// Unique-ish per app load so labels from a previous session can never collide
+const labelPrefix = 'kw' + Date.now().toString(36) + '-';
+
+/**
+ * Tracks our own outgoing messages that were rendered optimistically, so that the server
+ * echo (echo-message [+ labeled-response]) can be reconciled onto the existing message
+ * instead of appearing as a duplicate, and so messages that never got acknowledged can be
+ * flagged as failed and manually resent.
+ *
+ * One instance per network, created alongside the IRC client.
+ */
+export default class PendingMessages {
+    constructor(network) {
+        this.network = network;
+        // All unresolved entries, oldest first. state: 'pending' | 'failed'
+        this.entries = [];
+        // label => entry, for exact reconciliation via labeled-response
+        this.byLabel = new Map();
+        // Message object => entry, for the resend UI
+        this.byMessage = new Map();
+    }
+
+    isEchoEnabled() {
+        return this.network.ircClient.network.cap.isEnabled('echo-message');
+    }
+
+    isLabelEnabled() {
+        return this.isEchoEnabled() &&
+            this.network.ircClient.network.cap.isEnabled('labeled-response');
+    }
+
+    /**
+     * Send a message to a target, rendering it optimistically into the buffer and tracking
+     * it for echo reconciliation when the server supports it. This is the single send path
+     * for privmsg/action/notice so every sender gets the same behaviour.
+     *
+     * opts:
+     *   type       privmsg (default), action, notice or tagmsg
+     *   targetName wire target if it differs from buffer.name (eg. targeted messages @#chan)
+     *   tags       extra message tags to send
+     *   message    existing Message object to reuse (resends)
+     */
+    sendAndTrack(buffer, rawText, opts = {}) {
+        let network = this.network;
+        let state = network.appState;
+        let type = opts.type || 'privmsg';
+        let targetName = opts.targetName || buffer.name;
+        let tags = Object.assign({}, opts.tags);
+
+        // Special buffers (*bnc, *status, ...) are handled by the bouncer itself and
+        // never produce a network echo, so don't track or label those sends
+        let trackable = ['privmsg', 'action', 'notice'].indexOf(type) > -1 &&
+            !buffer.isSpecial();
+        let echoEnabled = trackable && this.isEchoEnabled();
+
+        let message = null;
+        if (opts.message) {
+            // Resending an existing (failed) message - reuse its bubble in the buffer
+            message = opts.message;
+            message.time = Date.now();
+            message.pending = echoEnabled;
+            message.send_failed = false;
+        } else {
+            let formatType = type === 'action' || type === 'notice' ?
+                type :
+                'privmsg';
+            let messageBody = TextFormatting.formatText(formatType, {
+                nick: network.nick,
+                text: rawText,
+            });
+
+            message = state.addMessage(buffer, {
+                time: Date.now(),
+                nick: network.nick,
+                message: messageBody,
+                tags: opts.tags || {},
+                type: type,
+                pending: echoEnabled,
+            });
+        }
+
+        if (echoEnabled && message) {
+            let label = this.isLabelEnabled() ?
+                labelPrefix + nextLabelNum++ :
+                null;
+            if (label) {
+                tags.label = label;
+            }
+            this.trackEntry({
+                label: label,
+                state: 'pending',
+                bufferName: buffer.name,
+                targetName: targetName,
+                message: message,
+                rawText: rawText,
+                type: type,
+                sentAt: Date.now(),
+                timer: null,
+            });
+        }
+
+        let client = network.ircClient;
+        let hasTags = Object.keys(tags).length > 0;
+        if (type === 'action') {
+            if (hasTags) {
+                // irc-framework's action() builds the CTCP via ctcpRequest() which cannot
+                // carry tags, so build the ACTION payload ourselves when a label is needed
+                client.say(targetName, '\x01ACTION ' + rawText + '\x01', tags);
+            } else {
+                client.action(targetName, rawText);
+            }
+        } else if (type === 'notice') {
+            client.notice(targetName, rawText, tags);
+        } else if (type === 'tagmsg') {
+            client.tagmsg(targetName, tags);
+        } else {
+            client.say(targetName, rawText, tags);
+        }
+
+        return message;
+    }
+
+    trackEntry(entry) {
+        // NOTE: long/multiline inputs are split by irc-framework into several PRIVMSGs that
+        // all share the same tags, so one label can come back on several echoes. Only the
+        // first echo reconciles the (single) optimistic message; the extra echoes fall
+        // through and get added normally, converging the buffer to the server's view.
+        entry.timer = setTimeout(() => this.markFailed(entry), SEND_TIMEOUT_MS);
+
+        this.sweepAckedEntries();
+        this.entries.push(entry);
+        if (entry.label) {
+            this.byLabel.set(entry.label, entry);
+        }
+        this.byMessage.set(entry.message, entry);
+
+        // Drop the oldest resolved-by-nothing entries if we somehow accumulate too many
+        while (this.entries.length > MAX_ENTRIES) {
+            this.removeEntry(this.entries[0]);
+        }
+    }
+
+    /**
+     * Try to match an incoming message event (live echo or history replay) against a tracked
+     * outgoing message. On a match the existing Message object adopts the server msgid, time
+     * and tags, and true is returned so the caller skips adding a duplicate.
+     */
+    reconcile(event, bufferName) {
+        if (this.entries.length === 0) {
+            return false;
+        }
+
+        let entry = null;
+
+        let label = event.tags && event.tags.label;
+        if (label && this.byLabel.has(label)) {
+            entry = this.byLabel.get(label);
+        } else {
+            entry = this.matchHeuristic(event, bufferName);
+        }
+
+        if (!entry) {
+            return false;
+        }
+
+        this.graft(entry, event);
+        return true;
+    }
+
+    // Content-based fallback used when the echo carries no (known) label: only our own
+    // messages with a server msgid, matching exactly one tracked entry by buffer, type and
+    // text. Each entry is consumed at most once, so repeated identical messages ("hi", "hi")
+    // are never over-deduplicated.
+    matchHeuristic(event, bufferName) {
+        let client = this.network.ircClient;
+        // Deliberate: a msgid is required. Without one there is no replay-dedup benefit to
+        // grafting, and the risk of consuming an unrelated self-message (eg. another of our
+        // clients relayed via znc.in/self-message, which carries no msgid) is much higher.
+        // A server with echo-message but no msgid will show the echo as a duplicate.
+        if (!event.tags || !event.tags.msgid) {
+            return null;
+        }
+        if (!event.nick || !client.caseCompare(event.nick, client.user.nick)) {
+            return null;
+        }
+
+        return this.entries.find((entry) => {
+            if (entry.type !== event.type) {
+                return false;
+            }
+            if (entry.rawText !== event.message) {
+                return false;
+            }
+            if (!client.caseCompare(entry.bufferName, bufferName || '')) {
+                return false;
+            }
+            // Pending entries are recent by definition (SEND_TIMEOUT). Failed entries stay
+            // matchable with no time limit: a history replay confirming an old "failed"
+            // message proves it actually reached the server.
+            return true;
+        }) || null;
+    }
+
+    graft(entry, event) {
+        let message = entry.message;
+        let buffer = this.network.bufferByName(entry.bufferName);
+
+        let msgid = event.tags.msgid || event.tags['draft/msgid'];
+        if (msgid && buffer) {
+            buffer.updateMessageId(message, msgid);
+        }
+
+        // Adopt the server's authoritative tags & time; strip the label as it is transient
+        let tags = Object.assign({}, event.tags);
+        delete tags.label;
+        message.tags = tags;
+        if (event.time) {
+            message.server_time = event.time;
+        }
+
+        message.pending = false;
+        message.send_failed = false;
+
+        this.removeEntry(entry);
+    }
+
+    /**
+     * The server acknowledged a labeled command without echoing a message back
+     * (labeled-response ACK). Eg. kiwibnc ACKs when the upstream cannot carry our label,
+     * or for messages it handles itself (*bnc). The message did reach the server so it
+     * must never be flagged as failed - but the entry stays tracked: in the heuristic
+     * fallback regime the (unlabeled) echo may still arrive later and needs to graft
+     * its msgid onto the optimistic message.
+     */
+    handleAck(label) {
+        if (!label || !this.byLabel.has(label)) {
+            return false;
+        }
+
+        let entry = this.byLabel.get(label);
+        clearTimeout(entry.timer);
+        entry.state = 'acked';
+        entry.ackedAt = Date.now();
+        entry.message.pending = false;
+        entry.message.send_failed = false;
+        return true;
+    }
+
+    // Lazily drop acked entries whose echo window has passed
+    sweepAckedEntries() {
+        let now = Date.now();
+        this.entries
+            .filter((e) => e.state === 'acked' && now - e.ackedAt > ACKED_TTL_MS)
+            .forEach((e) => this.removeEntry(e));
+    }
+
+    markFailed(entry) {
+        if (entry.state !== 'pending') {
+            return;
+        }
+        entry.state = 'failed';
+        entry.message.pending = false;
+        entry.message.send_failed = true;
+        // The entry stays tracked: a later history replay can still reconcile it (proving
+        // it was actually delivered), and the resend UI needs its rawText/type/buffer.
+    }
+
+    // Flag every in-flight message as failed, eg. when the connection drops.
+    failAll() {
+        this.entries.forEach((entry) => {
+            clearTimeout(entry.timer);
+            this.markFailed(entry);
+        });
+    }
+
+    canResend(message) {
+        let entry = this.byMessage.get(message);
+        return !!entry && entry.state === 'failed';
+    }
+
+    resend(message) {
+        let entry = this.byMessage.get(message);
+        if (!entry || entry.state !== 'failed') {
+            return false;
+        }
+
+        let buffer = this.network.bufferByName(entry.bufferName);
+        if (!buffer) {
+            return false;
+        }
+
+        this.removeEntry(entry);
+        this.sendAndTrack(buffer, entry.rawText, {
+            type: entry.type,
+            targetName: entry.targetName,
+            message: message,
+        });
+        return true;
+    }
+
+    removeEntry(entry) {
+        clearTimeout(entry.timer);
+        let idx = this.entries.indexOf(entry);
+        if (idx > -1) {
+            this.entries.splice(idx, 1);
+        }
+        if (entry.label) {
+            this.byLabel.delete(entry.label);
+        }
+        this.byMessage.delete(entry.message);
+    }
+}

--- a/src/libs/PendingMessages.js
+++ b/src/libs/PendingMessages.js
@@ -1,6 +1,10 @@
 'kiwi public';
 
+import { lineBreak } from 'irc-framework/src/linebreak';
 import * as TextFormatting from '@/helpers/TextFormatting';
+
+// Fallback wire budget when the client hasn't set message_max_length
+const DEFAULT_MAX_BYTES = 400;
 
 // How long we wait for the server echo before flagging a message as not sent
 const SEND_TIMEOUT_MS = 30000;
@@ -57,6 +61,55 @@ export default class PendingMessages {
      *   message    existing Message object to reuse (resends)
      */
     sendAndTrack(buffer, rawText, opts = {}) {
+        let type = opts.type || 'privmsg';
+
+        // A long privmsg/notice is split by irc-framework into several wire messages. If we
+        // tracked the whole thing as one optimistic message, each server echo would only
+        // carry a fragment and never match our full-text entry - the echoes would show as
+        // duplicates and the entry would time out as "not sent". So we split the same way
+        // here and track one optimistic message per wire line, keeping a 1:1 mapping with
+        // the echoes (and their msgids, so history replay dedups cleanly too).
+        // Resends (opts.message) already hold a single block. Actions go through the CTCP
+        // path which splits differently and are left as one block (rare to overflow).
+        let canSplit = !opts.message &&
+            (type === 'privmsg' || type === 'notice') &&
+            !buffer.isSpecial() &&
+            this.isEchoEnabled();
+
+        if (canSplit) {
+            let blocks = this.wireBlocks(rawText);
+            if (blocks.length > 1) {
+                let first = null;
+                blocks.forEach((block, i) => {
+                    let m = this.sendBlock(buffer, block, opts);
+                    if (i === 0) {
+                        first = m;
+                    }
+                });
+                return first;
+            }
+        }
+
+        return this.sendBlock(buffer, rawText, opts);
+    }
+
+    // Split text into the same wire blocks irc-framework's sendMessage would produce, so
+    // each optimistic message lines up with exactly one server echo.
+    wireBlocks(rawText) {
+        let client = this.network.ircClient;
+        let maxBytes = (client.options && client.options.message_max_length) || DEFAULT_MAX_BYTES;
+        let blocks = [];
+        rawText.split(/\r\n|\n|\r/).filter((line) => line).forEach((line) => {
+            blocks = blocks.concat([...lineBreak(line, {
+                bytes: maxBytes,
+                allowBreakingWords: true,
+                allowBreakingGraphemes: true,
+            })]);
+        });
+        return blocks;
+    }
+
+    sendBlock(buffer, rawText, opts = {}) {
         let network = this.network;
         let state = network.appState;
         let type = opts.type || 'privmsg';
@@ -137,10 +190,6 @@ export default class PendingMessages {
     }
 
     trackEntry(entry) {
-        // NOTE: long/multiline inputs are split by irc-framework into several PRIVMSGs that
-        // all share the same tags, so one label can come back on several echoes. Only the
-        // first echo reconciles the (single) optimistic message; the extra echoes fall
-        // through and get added normally, converging the buffer to the server's view.
         entry.timer = setTimeout(() => this.markFailed(entry), SEND_TIMEOUT_MS);
 
         this.sweepAckedEntries();

--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -574,7 +574,7 @@ function createNewState() {
                 // Some messages try to be added after a network has been removed, meaning no buffer
                 // will be available
                 if (!buffer || !buffer.getNetwork()) {
-                    return;
+                    return null;
                 }
 
                 let user = this.getUser(buffer.networkid, message.nick);
@@ -717,6 +717,8 @@ function createNewState() {
                 }
 
                 this.$emit('message.new', { message: bufferMessage, buffer });
+
+                return bufferMessage;
             },
 
             addMessageNoRepeat(buffer, message) {

--- a/src/libs/state/BufferState.js
+++ b/src/libs/state/BufferState.js
@@ -511,6 +511,23 @@ export default class BufferState {
         this.addMessageBatch(message);
     }
 
+    // Re-key a message that is already part of this buffer under a new id. Used when a server
+    // echo acknowledges an optimistically added message: the local numeric id is replaced by
+    // the server msgid so the history replay dedup (messageIds) recognises it.
+    updateMessageId(message, newId) {
+        let ids = this.messagesObj.messageIds;
+        if (ids[message.id] === message) {
+            delete ids[message.id];
+        }
+        message.id = newId;
+        // The message may still be sitting in the batchedAdd queue, in which case it is not in
+        // messageIds yet - it will be added under its new id when the batch flushes.
+        if (ids[newId] === undefined && this.messagesObj.messages.includes(message)) {
+            ids[newId] = message;
+        }
+        this.message_count++;
+    }
+
     updateLatestMessages(message) {
         if (!['privmsg', 'notice'].includes(message.type)) {
             return;
@@ -535,24 +552,10 @@ export default class BufferState {
 
     say(message, opts = {}) {
         let network = this.getNetwork();
-        let newMessage = {
-            time: Date.now(),
-            nick: network.nick,
-            message: message,
-            tags: opts.tags || {},
+        return network.pendingMessages.sendAndTrack(this, message, {
             type: opts.type || 'privmsg',
-        };
-
-        this.state.addMessage(this, newMessage);
-
-        let fnNames = {
-            privmsg: 'say',
-            action: 'action',
-            notice: 'notice',
-            tagmsg: 'tagmsg',
-        };
-        let fnName = fnNames[opts.type] || 'say';
-        network.ircClient[fnName](this.name, message, opts.tags);
+            tags: opts.tags,
+        });
     }
 
     join() {

--- a/src/res/locales/app.dev.po
+++ b/src/res/locales/app.dev.po
@@ -643,6 +643,14 @@ msgstr "Loading previous messages..."
 msgid "unread_messages"
 msgstr "Unread Messages"
 
+#: Not sent
+msgid "message_not_sent"
+msgstr "Not sent."
+
+#: Resend
+msgid "message_resend"
+msgstr "Resend"
+
 #: Reply in private
 msgid "reply_in_private"
 msgstr "Reply in private"

--- a/tests/unit/PendingMessages.spec.js
+++ b/tests/unit/PendingMessages.spec.js
@@ -9,6 +9,7 @@ function setup(caps = ['echo-message', 'labeled-response']) {
 
     let mockClient = {
         user: { nick: 'tester' },
+        options: { message_max_length: 350 },
         network: {
             cap: { isEnabled: (c) => caps.includes(c) },
             options: {},
@@ -93,6 +94,55 @@ describe('PendingMessages sending', () => {
         pending.sendAndTrack(buffer, 'waves', { type: 'action' });
 
         expect(client.action).toHaveBeenCalledWith('#test', 'waves');
+    });
+});
+
+describe('PendingMessages message splitting', () => {
+    // A word-based long line the wire budget must break into several PRIVMSGs
+    const longText = Array.from({ length: 60 }, (_, i) => 'word' + i).join(' ');
+
+    it('splits a long message into one tracked optimistic message per wire block', () => {
+        let { buffer, pending, client } = setup();
+        client.options.message_max_length = 100;
+
+        pending.sendAndTrack(buffer, longText);
+
+        let sentBlocks = client.say.mock.calls.map((c) => c[1]);
+        expect(sentBlocks.length).toBeGreaterThan(1);
+        // Every optimistic message and every wire send line up 1:1
+        expect(buffer.getMessages()).toHaveLength(sentBlocks.length);
+        expect(pending.entries).toHaveLength(sentBlocks.length);
+        // Each wire block carries its own unique label
+        let labels = client.say.mock.calls.map((c) => c[2].label);
+        expect(new Set(labels).size).toBe(labels.length);
+        // Rejoining the blocks reproduces the original text
+        expect(sentBlocks.join(' ')).toBe(longText);
+    });
+
+    it('reconciles each fragment echo, leaving no duplicates or failures', () => {
+        let { buffer, pending, client } = setup();
+        client.options.message_max_length = 100;
+
+        pending.sendAndTrack(buffer, longText);
+        let blocks = client.say.mock.calls.map((c) => c[1]);
+
+        // The server echoes each wire block back as its own message
+        blocks.forEach((block) => {
+            let event = echoEvent(block);
+            expect(pending.reconcile(event, '#test')).toBe(true);
+        });
+
+        expect(buffer.getMessages()).toHaveLength(blocks.length);
+        expect(buffer.getMessages().every((m) => !m.pending && !m.send_failed)).toBe(true);
+    });
+
+    it('does not split short messages (fast path)', () => {
+        let { buffer, pending, client } = setup();
+
+        pending.sendAndTrack(buffer, 'short one');
+
+        expect(client.say).toHaveBeenCalledTimes(1);
+        expect(buffer.getMessages()).toHaveLength(1);
     });
 });
 

--- a/tests/unit/PendingMessages.spec.js
+++ b/tests/unit/PendingMessages.spec.js
@@ -225,12 +225,50 @@ describe('PendingMessages reconciliation', () => {
         expect(pending.reconcile(event, '#test')).toBe(false);
     });
 
-    it('does not match echoes for other buffers', () => {
+    it('reconciles our own echo even when it resolves to a different buffer name', () => {
+        // InspIRCd echoes can resolve to a different buffer than where we rendered the
+        // optimistic copy; nick + content are authoritative, so buffer is not required
         let { buffer, pending } = setup(['echo-message']);
 
-        pending.sendAndTrack(buffer, 'hello');
+        let message = pending.sendAndTrack(buffer, 'hello');
+        let event = echoEvent('hello');
 
-        expect(pending.reconcile(echoEvent('hello'), '#other')).toBe(false);
+        expect(pending.reconcile(event, '#other')).toBe(true);
+        expect(message.id).toBe(event.tags.msgid);
+    });
+
+    it('prefers the same-buffer entry for identical content sent to two channels', () => {
+        let { s, network, buffer, pending } = setup(['echo-message']);
+        let other = s.addBuffer(network.id, '#other');
+
+        let msgTest = pending.sendAndTrack(buffer, 'gm');
+        let msgOther = pending.sendAndTrack(other, 'gm');
+
+        // Echo for #other must graft onto the #other copy, not the earlier #test one
+        let echoOther = echoEvent('gm');
+        expect(pending.reconcile(echoOther, '#other')).toBe(true);
+        expect(msgOther.id).toBe(echoOther.tags.msgid);
+        expect(msgTest.pending).toBe(true);
+
+        let echoTest = echoEvent('gm');
+        expect(pending.reconcile(echoTest, '#test')).toBe(true);
+        expect(msgTest.id).toBe(echoTest.tags.msgid);
+    });
+
+    it('reconciles reordered multi-line echoes independently by content', () => {
+        let { buffer, pending } = setup(['echo-message']);
+
+        let m1 = pending.sendAndTrack(buffer, 'line one');
+        let m2 = pending.sendAndTrack(buffer, 'line two');
+
+        // Server echoes them back in the opposite order
+        let e2 = echoEvent('line two');
+        let e1 = echoEvent('line one');
+        expect(pending.reconcile(e2, '#test')).toBe(true);
+        expect(pending.reconcile(e1, '#test')).toBe(true);
+
+        expect(m2.id).toBe(e2.tags.msgid);
+        expect(m1.id).toBe(e1.tags.msgid);
     });
 });
 

--- a/tests/unit/PendingMessages.spec.js
+++ b/tests/unit/PendingMessages.spec.js
@@ -1,0 +1,366 @@
+import state from '@/libs/state';
+import PendingMessages from '@/libs/PendingMessages';
+
+function setup(caps = ['echo-message', 'labeled-response']) {
+    let s = state.create();
+    let network = s.addNetwork('TestNet', 'tester', {});
+    network.nick = 'tester';
+    let buffer = s.addBuffer(network.id, '#test');
+
+    let mockClient = {
+        user: { nick: 'tester' },
+        network: {
+            cap: { isEnabled: (c) => caps.includes(c) },
+            options: {},
+        },
+        caseCompare: (a, b) => (a || '').toLowerCase() === (b || '').toLowerCase(),
+        say: jest.fn(),
+        notice: jest.fn(),
+        action: jest.fn(),
+        tagmsg: jest.fn(),
+    };
+    network.frameworkClient = mockClient;
+
+    let pending = new PendingMessages(network);
+    Object.defineProperty(network, 'pendingMessages', { writable: true, value: pending });
+
+    return { s, network, buffer, pending, client: mockClient };
+}
+
+// Build the echo event the IRC client would receive back from the server
+function echoEvent(text, tags = {}, over = {}) {
+    return {
+        nick: 'tester',
+        message: text,
+        type: 'privmsg',
+        time: Date.now(),
+        tags: { msgid: 'srv-' + Math.random().toString(36).substr(2), ...tags },
+        ...over,
+    };
+}
+
+describe('PendingMessages sending', () => {
+    it('renders the message optimistically as pending and sends it with a label', () => {
+        let { buffer, pending, client } = setup();
+
+        let message = pending.sendAndTrack(buffer, 'hello world');
+
+        expect(message.pending).toBe(true);
+        expect(buffer.getMessages()).toHaveLength(1);
+        expect(client.say).toHaveBeenCalledTimes(1);
+
+        let [target, text, tags] = client.say.mock.calls[0];
+        expect(target).toBe('#test');
+        expect(text).toBe('hello world');
+        expect(tags.label).toBeTruthy();
+    });
+
+    it('sends without a label but still tracks when only echo-message is enabled', () => {
+        let { buffer, pending, client } = setup(['echo-message']);
+
+        let message = pending.sendAndTrack(buffer, 'hello');
+
+        expect(message.pending).toBe(true);
+        let [, , tags] = client.say.mock.calls[0];
+        expect(tags.label).toBeUndefined();
+        expect(pending.entries).toHaveLength(1);
+    });
+
+    it('keeps the current behaviour when no echo caps are enabled', () => {
+        let { buffer, pending, client } = setup([]);
+
+        let message = pending.sendAndTrack(buffer, 'hello');
+
+        expect(message.pending).toBe(false);
+        expect(pending.entries).toHaveLength(0);
+        expect(client.say).toHaveBeenCalledWith('#test', 'hello', {});
+    });
+
+    it('sends labeled actions as a raw CTCP via say()', () => {
+        let { buffer, pending, client } = setup();
+
+        pending.sendAndTrack(buffer, 'waves', { type: 'action' });
+
+        expect(client.action).not.toHaveBeenCalled();
+        let [, text, tags] = client.say.mock.calls[0];
+        expect(text).toBe('\x01ACTION waves\x01');
+        expect(tags.label).toBeTruthy();
+    });
+
+    it('uses client.action() for unlabeled actions', () => {
+        let { buffer, pending, client } = setup([]);
+
+        pending.sendAndTrack(buffer, 'waves', { type: 'action' });
+
+        expect(client.action).toHaveBeenCalledWith('#test', 'waves');
+    });
+});
+
+describe('PendingMessages reconciliation', () => {
+    it('reconciles the labeled echo onto the optimistic message', () => {
+        let { buffer, pending, client } = setup();
+
+        let message = pending.sendAndTrack(buffer, 'hello');
+        let label = client.say.mock.calls[0][2].label;
+
+        let event = echoEvent('hello', { label });
+        expect(pending.reconcile(event, '#test')).toBe(true);
+
+        expect(buffer.getMessages()).toHaveLength(1);
+        expect(message.id).toBe(event.tags.msgid);
+        expect(message.pending).toBe(false);
+        expect(message.tags.msgid).toBe(event.tags.msgid);
+        expect(message.tags.label).toBeUndefined();
+        expect(buffer.messagesObj.messageIds[event.tags.msgid]).toBe(message);
+    });
+
+    it('dedups the history replay via messageIds after the msgid was grafted', () => {
+        let { s, buffer, pending, client } = setup();
+
+        pending.sendAndTrack(buffer, 'hello');
+        let label = client.say.mock.calls[0][2].label;
+        let event = echoEvent('hello', { label });
+        pending.reconcile(event, '#test');
+
+        // Simulate the CHATHISTORY replay of the same message after a reconnect
+        s.addMessage(buffer, {
+            time: Date.now(),
+            nick: 'tester',
+            message: 'hello',
+            type: 'privmsg',
+            tags: { msgid: event.tags.msgid },
+        });
+
+        expect(buffer.getMessages()).toHaveLength(1);
+    });
+
+    it('matches heuristically when the echo has no label', () => {
+        let { buffer, pending } = setup(['echo-message']);
+
+        let message = pending.sendAndTrack(buffer, 'hello');
+        let event = echoEvent('hello');
+
+        expect(pending.reconcile(event, '#test')).toBe(true);
+        expect(message.id).toBe(event.tags.msgid);
+        expect(buffer.getMessages()).toHaveLength(1);
+    });
+
+    it('never over-deduplicates repeated identical messages', () => {
+        let { buffer, pending } = setup(['echo-message']);
+
+        let first = pending.sendAndTrack(buffer, 'hi');
+        let second = pending.sendAndTrack(buffer, 'hi');
+
+        let echo1 = echoEvent('hi');
+        let echo2 = echoEvent('hi');
+
+        expect(pending.reconcile(echo1, '#test')).toBe(true);
+        expect(pending.reconcile(echo2, '#test')).toBe(true);
+
+        // Both optimistic messages remain, each with its own server msgid
+        expect(buffer.getMessages()).toHaveLength(2);
+        expect(first.id).toBe(echo1.tags.msgid);
+        expect(second.id).toBe(echo2.tags.msgid);
+
+        // A third identical echo (eg. from another client) must not match anything
+        expect(pending.reconcile(echoEvent('hi'), '#test')).toBe(false);
+    });
+
+    it('does not heuristically match messages from other people', () => {
+        let { buffer, pending } = setup(['echo-message']);
+
+        pending.sendAndTrack(buffer, 'hello');
+        let event = echoEvent('hello', {}, { nick: 'someoneelse' });
+
+        expect(pending.reconcile(event, '#test')).toBe(false);
+    });
+
+    it('does not match echoes for other buffers', () => {
+        let { buffer, pending } = setup(['echo-message']);
+
+        pending.sendAndTrack(buffer, 'hello');
+
+        expect(pending.reconcile(echoEvent('hello'), '#other')).toBe(false);
+    });
+});
+
+describe('PendingMessages failure & resend', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('flags a message as failed when no echo arrives in time', () => {
+        let { buffer, pending } = setup();
+
+        let message = pending.sendAndTrack(buffer, 'hello');
+        expect(message.pending).toBe(true);
+
+        jest.advanceTimersByTime(31000);
+
+        expect(message.pending).toBe(false);
+        expect(message.send_failed).toBe(true);
+        expect(pending.canResend(message)).toBe(true);
+    });
+
+    it('flags all in-flight messages as failed on disconnect', () => {
+        let { buffer, pending } = setup();
+
+        let m1 = pending.sendAndTrack(buffer, 'one');
+        let m2 = pending.sendAndTrack(buffer, 'two');
+
+        pending.failAll();
+
+        expect(m1.send_failed).toBe(true);
+        expect(m2.send_failed).toBe(true);
+    });
+
+    it('resends a failed message reusing the same message object', () => {
+        let { buffer, pending, client } = setup();
+
+        let message = pending.sendAndTrack(buffer, 'hello');
+        pending.failAll();
+        expect(message.send_failed).toBe(true);
+
+        expect(pending.resend(message)).toBe(true);
+
+        expect(message.pending).toBe(true);
+        expect(message.send_failed).toBe(false);
+        expect(client.say).toHaveBeenCalledTimes(2);
+        // No new message bubble was created
+        expect(buffer.getMessages()).toHaveLength(1);
+
+        // The new echo reconciles onto the same message
+        let label = client.say.mock.calls[1][2].label;
+        let event = echoEvent('hello', { label });
+        expect(pending.reconcile(event, '#test')).toBe(true);
+        expect(message.id).toBe(event.tags.msgid);
+    });
+
+    it('un-fails a failed message when the history replay proves it was delivered', () => {
+        let { buffer, pending } = setup(['echo-message']);
+
+        let message = pending.sendAndTrack(buffer, 'hello');
+        pending.failAll();
+        expect(message.send_failed).toBe(true);
+
+        // Reconnect: CHATHISTORY replays the message - it did reach the server
+        let event = echoEvent('hello');
+        expect(pending.reconcile(event, '#test')).toBe(true);
+
+        expect(message.send_failed).toBe(false);
+        expect(message.id).toBe(event.tags.msgid);
+        expect(buffer.getMessages()).toHaveLength(1);
+    });
+
+    it('resends to the original wire target when it differs from the buffer name', () => {
+        let { buffer, pending, client } = setup();
+
+        // Statusmsg-style send: displayed in #test but sent to @#test
+        let message = pending.sendAndTrack(buffer, 'ops only', { targetName: '@#test' });
+        expect(client.say.mock.calls[0][0]).toBe('@#test');
+
+        pending.failAll();
+        expect(pending.resend(message)).toBe(true);
+
+        expect(client.say).toHaveBeenCalledTimes(2);
+        expect(client.say.mock.calls[1][0]).toBe('@#test');
+    });
+
+    it('refuses to resend a message that is not in a failed state', () => {
+        let { buffer, pending } = setup();
+
+        let message = pending.sendAndTrack(buffer, 'hello');
+
+        expect(pending.resend(message)).toBe(false);
+        expect(pending.canResend(message)).toBe(false);
+    });
+});
+
+describe('PendingMessages labeled ACK', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('clears the pending state and prevents a timeout failure', () => {
+        let { buffer, pending, client } = setup();
+
+        let message = pending.sendAndTrack(buffer, 'hello');
+        let label = client.say.mock.calls[0][2].label;
+
+        expect(pending.handleAck(label)).toBe(true);
+        expect(message.pending).toBe(false);
+        expect(message.send_failed).toBe(false);
+
+        jest.advanceTimersByTime(31000);
+        expect(message.send_failed).toBe(false);
+    });
+
+    it('keeps an acked entry graftable by a later unlabeled echo', () => {
+        let { buffer, pending, client } = setup();
+
+        let message = pending.sendAndTrack(buffer, 'hello');
+        let label = client.say.mock.calls[0][2].label;
+        pending.handleAck(label);
+
+        // The upstream echo arrives later without our label (heuristic regime)
+        let event = echoEvent('hello');
+        expect(pending.reconcile(event, '#test')).toBe(true);
+        expect(message.id).toBe(event.tags.msgid);
+        expect(buffer.getMessages()).toHaveLength(1);
+    });
+
+    it('does not flag acked entries as failed on disconnect', () => {
+        let { buffer, pending, client } = setup();
+
+        let message = pending.sendAndTrack(buffer, 'hello');
+        pending.handleAck(client.say.mock.calls[0][2].label);
+
+        pending.failAll();
+        expect(message.send_failed).toBe(false);
+    });
+
+    it('ignores unknown or missing labels', () => {
+        let { pending } = setup();
+
+        expect(pending.handleAck('nope')).toBe(false);
+        expect(pending.handleAck(undefined)).toBe(false);
+    });
+
+    it('expires acked entries after their echo window, keeping failed ones', () => {
+        let { buffer, pending, client } = setup();
+
+        pending.sendAndTrack(buffer, 'acked msg');
+        pending.handleAck(client.say.mock.calls[0][2].label);
+        pending.sendAndTrack(buffer, 'failed msg');
+        pending.failAll();
+
+        // A minute later a new send triggers the lazy sweep
+        jest.advanceTimersByTime(61000);
+        pending.sendAndTrack(buffer, 'later msg');
+
+        let states = pending.entries.map((e) => e.state);
+        expect(states).toEqual(['failed', 'pending']);
+    });
+});
+
+describe('PendingMessages special buffers', () => {
+    it('does not track or label messages to special buffers', () => {
+        let { s, network, pending, client } = setup();
+        let bncBuffer = s.addBuffer(network.id, '*bnc');
+
+        let message = pending.sendAndTrack(bncBuffer, 'help');
+
+        expect(message.pending).toBe(false);
+        expect(pending.entries).toHaveLength(0);
+        let [target, text, tags] = client.say.mock.calls[0];
+        expect(target).toBe('*bnc');
+        expect(text).toBe('help');
+        expect(tags.label).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Own messages were rendered optimistically with a local numeric id while the server copy (live echo or CHATHISTORY replay) carries a msgid, so the msgid-only dedup never matched and reconnects duplicated our own recent messages.

All outgoing privmsg/action/notice now flow through a single path, PendingMessages.sendAndTrack: the optimistic copy is tracked as pending and sent with a unique label when the server supports labeled-response (requested alongside echo-message). The returning echo is reconciled onto the existing message - exact match by label, content+time heuristic as fallback - grafting the server msgid so history replay dedups naturally via messageIds.

A labeled ACK (eg. kiwibnc when no echo will follow) resolves the pending state without ever flagging failure. Messages with no acknowledgement after 30s or when the connection drops are flagged "not sent" with a manual resend action in all three message layouts.

Servers without these caps keep the exact previous behaviour.